### PR TITLE
New Rule Proj2002: Sort resource file values alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To add a props file:
 </Project>
 ```
 
-## Rules
+## MS Build project file rules
 * [**Proj0001** MS Build project file could not be located](rules/Proj0001.md)
 * [**Proj0002** Upgrade legacy MS Build project files](rules/Proj0002.md)
 * [**Proj0003** Define usings explicit](rules/Proj0003.md)
@@ -65,6 +65,9 @@ To add a props file:
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)
+
+## Resource file rules
+* [**Proj2002** Sort resource file values alphabetically](rules/Proj2002.md)
 
 ## Reference an analyzer from a project
 For debugging/development purposes, it can be useful to reference the analyzer

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 		rules\Proj1003.md = rules\Proj1003.md
+		rules\Proj2002.md = rules\Proj2002.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6-1449-41AA-8AD3-FA84194CE5B4}"
@@ -96,6 +97,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{08FA6376
 	ProjectSection(SolutionItems) = preProject
 		props\common.props = props\common.props
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxUnsorted", "projects\ResxUnsorted\ResxUnsorted.csproj", "{702BA67B-F900-4BFE-8D0F-990268A8FBDA}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -187,6 +190,10 @@ Global
 		{34060657-A2BE-4B96-BB4D-CFAD520D5C9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{34060657-A2BE-4B96-BB4D-CFAD520D5C9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{34060657-A2BE-4B96-BB4D-CFAD520D5C9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{702BA67B-F900-4BFE-8D0F-990268A8FBDA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{702BA67B-F900-4BFE-8D0F-990268A8FBDA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{702BA67B-F900-4BFE-8D0F-990268A8FBDA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{702BA67B-F900-4BFE-8D0F-990268A8FBDA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -216,6 +223,7 @@ Global
 		{273AA11D-101D-489D-AF98-5EFB040169CE} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{34060657-A2BE-4B96-BB4D-CFAD520D5C9A} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{08FA6376-1F6C-47C2-8C29-B93AC20A491A} = {BED71055-3C56-4C5B-9D83-A7B2CCD3B8CA}
+		{702BA67B-F900-4BFE-8D0F-990268A8FBDA} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/CompliantCSharp/Messages.nl.resx
+++ b/projects/CompliantCSharp/Messages.nl.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+ <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="King" xml:space="preserve">
+    <value>Koning</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+    <value>Hallo, wereld!</value>
+  </data>
+</root>

--- a/projects/CompliantCSharp/Messages.resx
+++ b/projects/CompliantCSharp/Messages.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="King" xml:space="preserve">
+    <value>King</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+    <value>Hello, world!</value>
+  </data>
+</root>

--- a/projects/CompliantVB/CompliantVB.vbproj
+++ b/projects/CompliantVB/CompliantVB.vbproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>CompliantVB</RootNamespace>
@@ -10,9 +10,9 @@
   <ItemGroup Label="Analyzers">
     <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <AdditionalFiles Include="*.vbproj" Visible="false" />
   </ItemGroup>
-
+  
 </Project>

--- a/projects/CompliantVB/Messages.nl.resx
+++ b/projects/CompliantVB/Messages.nl.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+ <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="King" xml:space="preserve">
+    <value>Koning</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+    <value>Hallo, wereld!</value>
+  </data>
+</root>

--- a/projects/CompliantVB/Messages.resx
+++ b/projects/CompliantVB/Messages.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="King" xml:space="preserve">
+    <value>King</value>
+  </data>
+  <data name="Welcome" xml:space="preserve">
+    <value>Hello, world!</value>
+  </data>
+</root>

--- a/projects/ResxUnsorted/Placeholder.cs
+++ b/projects/ResxUnsorted/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace ResourceFiles;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/ResxUnsorted/Resources.resx
+++ b/projects/ResxUnsorted/Resources.resx
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="A" xml:space="preserve">
+    <value>A value</value>
+  </data>
+  <data name="C" xml:space="preserve">
+    <value>C value</value>
+  </data>
+  <data name="B" xml:space="preserve">
+    <value>B value</value>
+  </data>
+</root>

--- a/projects/ResxUnsorted/ResxUnsorted.csproj
+++ b/projects/ResxUnsorted/ResxUnsorted.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+  </PropertyGroup>
+
+</Project>

--- a/rules/Proj0005.md
+++ b/rules/Proj0005.md
@@ -22,7 +22,7 @@ as XML attributes, instead of XML elements.
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">
-    <PackageReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj0007.md
+++ b/rules/Proj0007.md
@@ -24,7 +24,7 @@ Empty nodes only add noise, as they contain no information.
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />	
+    <PackageReference Include="DotNetProjectFile.Analyzers" Version="* PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />	
   </ItemGroup>
 
 </Project>

--- a/rules/Proj1000.md
+++ b/rules/Proj1000.md
@@ -7,7 +7,7 @@ This can be achieved by adding the analyzers to the [Directory.Build.targets](ht
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzer">
-    <ProjectReference Include="DotNetProjectFile.Analyzers" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="DotNetProjectFile.Analyzers" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj1001.md
+++ b/rules/Proj1001.md
@@ -18,3 +18,21 @@ The following analyzers are known to be beneficial for some packages:
 | [NUnit.Analyzers](https://www.nuget.org/packages/NUnit.Analyzers)                                                     | [NUnit.*](https://www.nuget.org/packages?q=NUnit.*)                                                 |
 | [SerilogAnalyzer](https://www.nuget.org/packages/SerilogAnalyzer)                                                     | [Serilog.*](https://www.nuget.org/packages?q=Serilog.*)                                             |
 | [xunit.analyzers](https://www.nuget.org/packages/xunit.analyzers)                                                     | [xunit.*](https://www.nuget.org/packages?q=xunit.*)                                                 |
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup Label="Analyzers">
+    <PackageReference Include="Microsoft.AspNetCore.Components.Analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.Azure.Functions.Analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="MongoDB.Analyzer" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="NUnit.Analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SerilogAnalyzer" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="xunit.analyzers" Version="*" PrivateAssets="All" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+  </ItemGroup>
+
+</Project>
+ ```

--- a/rules/Proj1003.md
+++ b/rules/Proj1003.md
@@ -13,7 +13,7 @@ For C# projects:
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">
-    <ProjectReference Include="SonarAnalyzer.CSharp" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="*" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>
@@ -24,7 +24,7 @@ For VB.NET projects:
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup Label="Analyzers">
-    <ProjectReference Include="SonarAnalyzer.VisualBasic" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
+    <PackageReference Include="SonarAnalyzer.VisualBasic" Version="* PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
 
 </Project>

--- a/rules/Proj2002.md
+++ b/rules/Proj2002.md
@@ -1,0 +1,33 @@
+# Proj2002: Sort resource file values alphabetically
+To improve readability, and reduce the number of merge conflicts, the `<data>`
+elements should be sorted based on the `@name` attribute.
+
+## Non-compliant
+``` XML
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- ... -->
+  <data name="Queen" xml:space="preserve">
+    <value>Koningin</value>
+  </data>
+  <data name="King" xml:space="preserve">
+    <value>Koning</value>
+  </data>
+</root>
+```
+
+## Compliant
+``` XML
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- ... -->
+  <data name="King" xml:space="preserve">
+    <value>Koning</value>
+  </data>
+  <data name="Queen" xml:space="preserve">
+    <value>Koningin</value>
+  </data>
+</root>
+```
+
+

--- a/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Design_specs.cs
@@ -14,7 +14,9 @@ public class Rules
 
     [TestCaseSource(nameof(Types))]
     public void in_DotNetProjectFile_Analyzers_MsBuild_namespace(Type type)
-        => type.Namespace.Should().Be("DotNetProjectFile.Analyzers.MsBuild");
+        => type.Namespace.Should().BeOneOf(
+            "DotNetProjectFile.Analyzers.MsBuild",
+            "DotNetProjectFile.Analyzers.Resx");
 
     [TestCaseSource(nameof(Types))]
     public void Has_supported_diagnostics(Type type)

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../props/common.props"/>
+  <Import Project="../../props/common.props" />
   
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>

--- a/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
@@ -7,3 +7,4 @@ global using Microsoft.CodeAnalysis.Diagnostics;
 global using NUnit.Framework;
 global using System.Diagnostics.Contracts;
 global using System.Text;
+global using Resx = DotNetProjectFile.Analyzers.Resx;

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Sort_data_alphabetically.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Sort_data_alphabetically.cs
@@ -1,0 +1,22 @@
+﻿namespace Rules.RESX.Sort_data_alphabetically;
+
+public class Reports
+{
+    [Test]
+    public void unsorted_data()
+        => new Resx.SortDataAlphabetically()
+        .ForProject("ResxUnsorted.cs")
+        .HasIssue(
+            new Issue("Proj2002", "Resource values should be ordered alphabetically by their names.").WithSpan(17, 3, 19, 9));
+}
+
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void sorted_data(string project)
+         => new Resx.SortDataAlphabetically()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/ResourceFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/ResourceFileAnalyzer.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Immutable;
+
+namespace DotNetProjectFile.Analyzers;
+
+public abstract class ResourceFileAnalyzer : DiagnosticAnalyzer
+{
+    protected ResourceFileAnalyzer(DiagnosticDescriptor primaryDiagnostic, params DiagnosticDescriptor[] supportedDiagnostics)
+        => SupportedDiagnostics = new[] { primaryDiagnostic }.Concat(supportedDiagnostics).ToImmutableArray();
+
+    public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+
+    public DiagnosticDescriptor Descriptor => SupportedDiagnostics[0];
+
+    public sealed override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+        Register(context);
+    }
+
+    protected virtual void Register(AnalysisContext context)
+        => context.RegisterResourceFileAction(Register);
+
+    protected abstract void Register(ResourceFileAnalysisContext context);
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/SortDataAlphabetically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/SortDataAlphabetically.cs
@@ -1,0 +1,24 @@
+﻿namespace DotNetProjectFile.Analyzers.Resx;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class SortDataAlphabetically : ResourceFileAnalyzer
+{
+    public SortDataAlphabetically() : base(Rule.SortDataAlphabetically) { }
+
+    protected override void Register(ResourceFileAnalysisContext context)
+    {
+        var sorted = context.Resource.Data
+            .Select(d => d.Name)
+            .OrderBy(d => d)
+            .ToArray();
+
+        for (var i = 0; i < sorted.Length; i++)
+        {
+            if (context.Resource.Data[i].Name != sorted[i])
+            {
+                context.ReportDiagnostic(Descriptor, context.Resource.Data[i]);
+                return;
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locatable.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locatable.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetProjectFile.CodeAnalysis;
+
+public interface Locatable
+{
+    Location Location { get; }
+}

--- a/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locations.cs
+++ b/src/DotNetProjectFile.Analyzers/CodeAnalysis/Locations.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.CodeAnalysis.Text;
+using System.IO;
+using System.Xml;
+
+namespace DotNetProjectFile.CodeAnalysis;
+
+public static class Locations
+{
+    public static Location FromXml(FileInfo file, SourceText text, IXmlLineInfo info)
+    {
+        var linePositionSpan = info.LinePositionSpan();
+        var textSpan = text.TextSpan(linePositionSpan);
+        return Location.Create(file.FullName, textSpan, linePositionSpan);
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Diagnostics/ResourceFileAnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Diagnostics/ResourceFileAnalysisContext.cs
@@ -1,0 +1,36 @@
+﻿using DotNetProjectFile.CodeAnalysis;
+
+namespace DotNetProjectFile.Diagnostics;
+
+/// <summary>The context required to analyze a MS Build project file.</summary>
+public readonly struct ResourceFileAnalysisContext
+{
+    /// <summary>Gets the project file.</summary>
+    public readonly Resx.Resource Resource;
+
+    /// <summary>Gets the compilation.</summary>
+    public readonly Compilation Compilation;
+
+    /// <summary>Gets the analyzer options.</summary>
+    public readonly AnalyzerOptions Options;
+
+    /// <summary>Gets the cancellation token.</summary>
+    public readonly CancellationToken CancellationToken;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Action<Diagnostic> Report;
+
+    /// <summary>Initializes a new instance of the <see cref="ResourceFileAnalysisContext"/> struct.</summary>
+    public ResourceFileAnalysisContext(Resx.Resource resource, Compilation compilation, AnalyzerOptions options, CancellationToken cancellationToken, Action<Diagnostic> report)
+    {
+        Resource = resource;
+        Compilation = compilation;
+        Options = options;
+        CancellationToken = cancellationToken;
+        Report = report;
+    }
+
+    /// <summary>Reports a diagnostic about the project file.</summary>
+    public void ReportDiagnostic(DiagnosticDescriptor descriptor, Locatable location, params object?[]? messageArgs)
+        => Report(Diagnostic.Create(descriptor, location.Location, messageArgs));
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="../../props/common.props"/>
+  <Import Project="../../props/common.props" />
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -18,10 +18,12 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Authors>Corniel Nobel</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
-    <PackageTags>Code Analysis;Project files;csproj;vbproj</PackageTags>
+    <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
     <Version>1.0.5</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- Prop2002: Sort resource file values alphabetically. (NEW RULE)
 v1.0.5
 - Proj1003: Sonar Analyzers defined in prop. (FP)
 v1.0.4

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -17,4 +17,14 @@ internal static class AnalysisContextExtensions
                 }
             }
         });
+
+    /// <summary>Registers an action on <see cref="ProjectFileAnalysisContext"/>.</summary>
+    public static void RegisterResourceFileAction(this AnalysisContext context, Action<ResourceFileAnalysisContext> action)
+        => context.RegisterCompilationAction(c =>
+        {
+            foreach (var resource in DotNetProjectFile.Resx.Resources.Resolve(c.Options.AdditionalFiles))
+            {
+                action.Invoke(new(resource, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
+            }
+        });
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -65,21 +65,21 @@ public class Node
     public string? Attribute([CallerMemberName] string? propertyName = null)
         => Element.Attribute(propertyName)?.Value;
 
-    internal Node? Create(XElement element)
-    => element.Name.LocalName switch
-    {
-        null => null,
-        nameof(Folder) /*.................*/ => new Folder(element, Project),
-        nameof(ImplicitUsings) /*.........*/ => new ImplicitUsings(element, Project),
-        nameof(Import) /*.................*/ => new Import(element, Project),
-        nameof(ItemGroup) /*..............*/ => new ItemGroup(element, Project),
-        nameof(NuGetAudit) /*.............*/ => new NuGetAudit(element, Project),
-        nameof(PackageReference) /*.......*/ => new PackageReference(element, Project),
-        nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element, Project),
-        nameof(TargetFramework) /*........*/ => new TargetFramework(element, Project),
-        nameof(TargetFrameworks) /*.......*/ => new TargetFrameworks(element, Project),
-        _ => new Unknown(element, Project),
-    };
+    private Node? Create(XElement element)
+        => element.Name.LocalName switch
+        {
+            null => null,
+            nameof(Folder) /*.................*/ => new Folder(element, Project),
+            nameof(ImplicitUsings) /*.........*/ => new ImplicitUsings(element, Project),
+            nameof(Import) /*.................*/ => new Import(element, Project),
+            nameof(ItemGroup) /*..............*/ => new ItemGroup(element, Project),
+            nameof(NuGetAudit) /*.............*/ => new NuGetAudit(element, Project),
+            nameof(PackageReference) /*.......*/ => new PackageReference(element, Project),
+            nameof(PropertyGroup) /*..........*/ => new PropertyGroup(element, Project),
+            nameof(TargetFramework) /*........*/ => new TargetFramework(element, Project),
+            nameof(TargetFrameworks) /*.......*/ => new TargetFrameworks(element, Project),
+            _ => new Unknown(element, Project),
+        };
 
     protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)
         => Converters.TryConvert<T>(value, GetType(), propertyName!);

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -1,7 +1,7 @@
 # [.NET project file analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/)
 The package contains analyzers that analyze .NET project files.
 
-## Rules
+## MS Build project file rules
 * [**Proj0001** MS Build project file could not be located](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0001.md)
 * [**Proj0002** Upgrade legacy MS Build project files](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0002.md)
 * [**Proj0003** Define usings explicit](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0003.md)
@@ -14,3 +14,6 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/rules/Proj1003.md)
+
+## Resource file rules
+* [**Proj2002** Sort resource file values alphabetically](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/rules/Proj2002.md)

--- a/src/DotNetProjectFile.Analyzers/Resx/Data.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Data.cs
@@ -1,0 +1,17 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public sealed class Data : Node
+{
+    public Data(XElement element, Resource? resource)
+        : base(element, resource)
+    {
+        Name = element.Attribute("name")?.Value;
+        Value = Children<Value>().FirstOrDefault();
+    }
+
+    public string? Name { get; }
+
+    public Value? Value { get; }
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.Create.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.Create.cs
@@ -1,0 +1,15 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public partial class Node
+{
+    internal Node? Create(XElement element)
+        => element.Name.LocalName switch
+        {
+            null => null,
+            "data" /*..*/ => new Data(element, Resource),
+            "value" /*.*/ => new Value(element, Resource),
+            _ => new Unknown(element, Resource),
+        };
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Node.cs
@@ -1,0 +1,35 @@
+﻿using DotNetProjectFile.CodeAnalysis;
+using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public partial class Node : Locatable
+{
+    protected Node(XElement element, Resource? resource)
+    {
+        Element = element;
+        Resource = resource ?? (this as Resource) ?? throw new ArgumentNullException(nameof(resource));
+    }
+
+    public XElement Element { get; }
+
+    public Resource Resource { get; }
+
+    public Location Location => location ??= Locations.FromXml(Resource.Path, Resource.SourceText, Element);
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private Location? location;
+
+    /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
+    public Nodes<T> Children<T>() where T : Node => new(this);
+
+    /// <summary>Get all children.</summary>
+    /// <remarks>
+    /// This function exists as source for the <see cref="Nodes{T}"/>.
+    /// With this construction, we can expose all children as collection.
+    /// </remarks>
+    public Nodes<Node> Children() => children ??= Children<Node>();
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private Nodes<Node>? children;
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Nodes.cs
@@ -1,32 +1,33 @@
 ﻿using System.Globalization;
 
-namespace DotNetProjectFile.MsBuild;
+namespace DotNetProjectFile.Resx;
 
 /// <summary>Represents a collection of <see cref="Node"/>s.</summary>
 [DebuggerTypeProxy(typeof(CollectionDebugView))]
 [DebuggerDisplay("{DebuggerDisplay}")]
-public sealed class Nodes<T> : IEnumerable<T> where T : Node
+public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
 {
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly IReadOnlyList<T> Items;
+
     /// <summary>Initializes a new instance of the <see cref="Nodes{T}"/> class.</summary>
     /// <param name="parent">
     /// The parent <see cref="Node"/>.
     /// </param>
-    public Nodes(Node parent)
-    {
-        Parent = parent;
-    }
+    public Nodes(Node parent) => Items = parent.Element
+        .Elements().Select(parent.Create)
+        .Where(child => child is T)
+        .Cast<T>()
+        .ToArray();
 
     /// <summary>Gets the number of items.</summary>
-    public int Count => Items.Count();
+    public int Count => Items.Count;
 
     /// <summary>Gets the specified item.</summary>
     /// <param name="index">
     /// The index of the item.
     /// </param>
-    public T this[int index] => Items.Skip(index).FirstOrDefault();
-
-    /// <summary>The parent node.</summary>
-    private Node Parent { get; set; }
+    public T this[int index] => Items[index];
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
@@ -39,8 +40,4 @@ public sealed class Nodes<T> : IEnumerable<T> where T : Node
     /// <inheritdoc />
     [ExcludeFromCodeCoverage]
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
-
-    /// <summary>Helper property to select the needed children.</summary>
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private IEnumerable<T> Items => Parent.Children().Where(child => child is T).Cast<T>();
 }

--- a/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.CodeAnalysis.Text;
+using System.Globalization;
+using System.IO;
+using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public sealed class Resource : Node
+{
+    public Resource(FileInfo path, XElement element, SourceText sourceText, CultureInfo culture)
+        : base(element, null)
+    {
+        Path = path;
+        SourceText = sourceText;
+        Culture = culture;
+        Data = Children<Data>();
+    }
+
+    public FileInfo Path { get; }
+
+    public SourceText SourceText { get; }
+
+    public CultureInfo Culture { get; }
+
+    public Nodes<Data> Data { get; }
+
+    public static Resource Load(AdditionalText text)
+    {
+        var file = new FileInfo(text.Path);
+        var sourceText = text.GetText()!;
+        var element = TryElement(sourceText);
+        var culture = TryCulture(file);
+        return new(file, element, sourceText, culture);
+    }
+
+    private static XElement TryElement(SourceText sourceText)
+    {
+        try
+        {
+            return XElement.Parse(sourceText.ToString(), LoadOptions);
+        }
+        catch
+        {
+            return XElement.Parse(@"<root valid=""false"" />", LoadOptions);
+        }
+    }
+
+    private static CultureInfo TryCulture(FileInfo file)
+    {
+        var parts = file.Name.Split('.');
+
+        if (parts.Length > 2)
+        {
+            try
+            {
+                return CultureInfo.GetCultureInfo(parts[^2]);
+            }
+            catch (CultureNotFoundException)
+            {
+                // not a culture.
+            }
+        }
+        return CultureInfo.InvariantCulture;
+    }
+
+    private static readonly LoadOptions LoadOptions = LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo;
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Resources.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Resources.cs
@@ -1,0 +1,29 @@
+﻿using DotNetProjectFile.IO;
+using System.IO;
+
+namespace DotNetProjectFile.Resx;
+
+internal sealed class Resources : IReadOnlyCollection<Resource>
+{
+    private readonly Dictionary<FileInfo, Resource> items = new(FileSystemEqualityComparer.File);
+
+    public int Count => items.Count;
+
+    public IEnumerator<Resource> GetEnumerator() => items.Values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+    public static Resources Resolve(IEnumerable<AdditionalText> additionalFiles)
+    {
+        var resources = new Resources();
+
+        foreach (var additional in additionalFiles
+            .Where(a => string.Equals(Path.GetExtension(a.Path), ".resx", StringComparison.OrdinalIgnoreCase)))
+        {
+            var resource = Resource.Load(additional);
+            resources.items[resource.Path] = resource;
+        }
+
+        return resources;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Unknown.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Unknown.cs
@@ -1,0 +1,8 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public sealed class Unknown : Node
+{
+    public Unknown(XElement element, Resource? resource) : base(element, resource) { }
+}

--- a/src/DotNetProjectFile.Analyzers/Resx/Value.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Value.cs
@@ -1,0 +1,10 @@
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Resx;
+
+public sealed class Value : Node
+{
+    public Value(XElement element, Resource resource) : base(element, resource) { }
+
+    public string? Text => Element.Value;
+}

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -137,6 +137,17 @@ public static class Rule
         category: Category.CodeQuality,
         isEnabled: true);
 
+    public static DiagnosticDescriptor SortDataAlphabetically => New(
+        id: 2002,
+        title: "Sort resource file values alphabetically",
+        message: "Resource values should be ordered alphabetically by their names.",
+        description: 
+            "To improve readability, and reduce the number of merge conflicts, " +
+            "the `<data>` elements should be sorted based on the `@name` attribute.",
+        tags: new[] { "resx", "resources" },
+        category: Category.Clarity,
+        isEnabled: true);
+
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
     private static DiagnosticDescriptor New(


### PR DESCRIPTION
# Proj2002: Sort resource file values alphabetically
To improve readability, and reduce the number of merge conflicts, the `<data>` elements should be sorted based on the `@name` attribute.

## Non-compliant
``` XML
<?xml version="1.0" encoding="utf-8"?>
<root>
  <!-- ... -->
  <data name="Queen" xml:space="preserve">
    <value>Koningin</value>
  </data>
  <data name="King" xml:space="preserve">
    <value>Koning</value>
  </data>
</root>
```

## Compliant
``` XML
<?xml version="1.0" encoding="utf-8"?>
<root>
  <!-- ... -->
  <data name="King" xml:space="preserve">
    <value>Koning</value>
  </data>
  <data name="Queen" xml:space="preserve">
    <value>Koningin</value>
  </data>
</root>
```

See #30