### PR TITLE
New Rule Proj2004: Add invariant fallback value

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ To add a props file:
 * [**Proj2001** Define data in a resource file](rules/Proj2001.md)
 * [**Proj2002** Sort resource file values alphabetically](rules/Proj2002.md)
 * [**Proj2003** Add invariant fallback resources](rules/Proj2003.md)
+* [**Proj2004** Add invariant fallback values](rules/Proj2004.md)
 
 ## Reference an analyzer from a project
 For debugging/development purposes, it can be useful to reference the analyzer

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj2001.md = rules\Proj2001.md
 		rules\Proj2002.md = rules\Proj2002.md
 		rules\Proj2003.md = rules\Proj2003.md
+		rules\Proj2004.md = rules\Proj2004.md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6-1449-41AA-8AD3-FA84194CE5B4}"
@@ -113,6 +114,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxNoHeaders", "projects\ResxNoHeaders\ResxNoHeaders.csproj", "{5D3BAD0B-5B58-42B1-9A91-FFD758CF8F26}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxNoInvariant", "projects\ResxNoInvariant\ResxNoInvariant.csproj", "{5522D7B2-00F5-45C6-81B7-47EA8D899FF9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResxMissingInvariant", "projects\ResxMissingInvariant\ResxMissingInvariant.csproj", "{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -228,6 +231,10 @@ Global
 		{5522D7B2-00F5-45C6-81B7-47EA8D899FF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5522D7B2-00F5-45C6-81B7-47EA8D899FF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5522D7B2-00F5-45C6-81B7-47EA8D899FF9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -263,6 +270,7 @@ Global
 		{CA410FA1-C99B-4246-AB32-FD37CF27CB67} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{5D3BAD0B-5B58-42B1-9A91-FFD758CF8F26} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{5522D7B2-00F5-45C6-81B7-47EA8D899FF9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/ResxMissingInvariant/Chess.de-AT.resx
+++ b/projects/ResxMissingInvariant/Chess.de-AT.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+   <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+  <data name="Bishop" xml:space="preserve">
+    <value>Läufer</value>
+  </data>
+  <data name="Rook" xml:space="preserve">
+    <value>Turm</value>
+  </data>
+</root>

--- a/projects/ResxMissingInvariant/Chess.nl.resx
+++ b/projects/ResxMissingInvariant/Chess.nl.resx
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+   <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+  <data name="Knight" xml:space="preserve">
+    <value>Paard</value>
+  </data>
+  <data name="Pawn" xml:space="preserve">
+    <value>Pion</value>
+  </data>
+  <data name="Queen" xml:space="preserve">
+    <value>Dame</value>
+  </data>
+</root>

--- a/projects/ResxMissingInvariant/Chess.resx
+++ b/projects/ResxMissingInvariant/Chess.resx
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+   <resheader name="reader">
+    <value>System.Resources.ResXResourceReader</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter</value>
+  </resheader>
+  <data name="King" xml:space="preserve">
+    <value>King</value>
+  </data>
+  <data name="Queen" xml:space="preserve">
+    <value>Queen</value>
+  </data>
+</root>

--- a/projects/ResxMissingInvariant/Placeholder.cs
+++ b/projects/ResxMissingInvariant/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace ResxMissingInvariant;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/ResxMissingInvariant/ResxMissingInvariant.csproj
+++ b/projects/ResxMissingInvariant/ResxMissingInvariant.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);EmbeddedResource</AdditionalFileItemNames>
+  </PropertyGroup>
+
+</Project>

--- a/rules/Proj2004.md
+++ b/rules/Proj2004.md
@@ -1,4 +1,4 @@
-# Proj2003: Add invariant fallback value
+# Proj2004: Add invariant fallback value
 To ensure that localized values can be resolved, a localized value must have a
 culture invariant alternative.
 

--- a/rules/Proj2004.md
+++ b/rules/Proj2004.md
@@ -1,0 +1,5 @@
+# Proj2003: Add invariant fallback value
+To ensure that localized values can be resolved, a localized value must have a
+culture invariant alternative.
+
+See: https://learn.microsoft.com/en-us/dotnet/core/extensions/localization

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_values.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/RESX/Add_invariant_fallback_values.cs
@@ -1,0 +1,39 @@
+﻿namespace Rules.RESX.Add_invariant_fallback_values;
+
+public class Reports
+{
+    [Test]
+    public void missing_invariant_resource()
+        => new Resx.AddInvariantFallbackValues()
+        .ForProject("ResxMissingInvariant.cs")
+        .HasIssues(
+            new Issue("Proj2004", "Add invariant fallback value for 'Bishop'.").WithSpan(11, 3, 13, 9),
+            new Issue("Proj2004", "Add invariant fallback value for 'Rook'.").WithSpan(0014, 3, 16, 9),
+            new Issue("Proj2004", "Add invariant fallback value for 'Knight'.").WithSpan(11, 3, 13, 9),
+            new Issue("Proj2004", "Add invariant fallback value for 'Pawn'.").WithSpan(0014, 3, 16, 9));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void sorted_data(string project)
+         => new Resx.AddInvariantFallbackValues()
+        .ForProject(project)
+        .HasNoIssues();
+}
+
+public class Ignores
+{
+    [Test]
+    public void invalid_resources()
+         => new Resx.AddInvariantFallbackValues()
+        .ForProject("ResxNoXml.cs")
+        .HasNoIssues();
+
+    [Test]
+    public void missing_invariant_resource()
+        => new Resx.AddInvariantFallbackValues()
+       .ForProject("ResxNoInvariant.cs")
+       .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/Resx/AddInvariantFallbackValues.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/Resx/AddInvariantFallbackValues.cs
@@ -1,0 +1,19 @@
+﻿namespace DotNetProjectFile.Analyzers.Resx;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class AddInvariantFallbackValues : ResourceFileAnalyzer
+{
+    public AddInvariantFallbackValues() : base(Rule.AddInvariantFallbackValues) { }
+
+    protected override void Register(ResourceFileAnalysisContext context)
+    {
+        if (context.Resource is { ForInvariantCulture: false } resource
+            && resource.Parents.FirstOrDefault(p => p.ForInvariantCulture) is { } parent)
+        {
+            foreach (var data in resource.Data.Where(d => !parent.Contains(d.Name)))
+            {
+                context.ReportDiagnostic(Descriptor, data, data.Name);
+            }
+        }
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -20,10 +20,10 @@
     <Authors>Corniel Nobel</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.0.5</Version>
+    <Version>1.0.6</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-ToBeReleased
+v1.0.6
 - Proj0010: Define OutputType explicitly. (NEW RULE)
 - Proj1001: Reported dependency with missing analyser is now nearest name match. (FP)
 - Proj1001: Added 14 new package specific analyzers. (FN)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -31,6 +31,7 @@ ToBeReleased
 - Prop2001: Define data in a resource file. (NEW RULE)
 - Proj2002: Sort resource file values alphabetically. (NEW RULE)
 - Proj2003: Add invariant fallback resources. (NEW RULE)
+- Proj2004: Add invariant fallback values. (NEW RULE)
 v1.0.5
 - Proj1003: Sonar Analyzers defined in prop. (FP)
 v1.0.4

--- a/src/DotNetProjectFile.Analyzers/Extensions/System.Globalization.CultureInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/System.Globalization.CultureInfo.cs
@@ -6,16 +6,12 @@ internal static class CultureInfoExtensions
     {
         var parent = culture.Parent;
 
-        while (parent is { })
+        while (!parent.IsInvariant())
         {
             yield return parent;
             parent = parent.Parent;
-
-            if (parent.IsInvariant())
-            {
-                yield break;
-            }
         }
+        yield return CultureInfo.InvariantCulture;
     }
 
     public static bool IsInvariant(this CultureInfo culture) => culture == CultureInfo.InvariantCulture;

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -21,3 +21,4 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj2001** Define data in a resource file](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj2001.md)
 * [**Proj2002** Sort resource file values alphabetically](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj2002.md)
 * [**Proj2003** Add invariant fallback resources](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj2003.md)
+* [**Proj2004** Add invariant fallback values](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj2004.md)

--- a/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
+++ b/src/DotNetProjectFile.Analyzers/Resx/Resource.cs
@@ -5,8 +5,11 @@ using System.Xml.Linq;
 
 namespace DotNetProjectFile.Resx;
 
+[DebuggerDisplay("Culture = {Culture.Name}, Count = {Data.Count}")]
 public sealed class Resource : Node
 {
+    private readonly Dictionary<string, Data> lookup = new();
+
     public Resource(
         ResourceFileInfo path,
         XElement element,
@@ -21,6 +24,11 @@ public sealed class Resource : Node
         Resources = resources;
         Headers = Children<ResHeader>();
         Data = Children<Data>();
+
+        foreach (var data in Data.Where(d => d.Name is { Length: > 0 }))
+        {
+            lookup[data.Name!] = data;
+        }
     }
 
     public ResourceFileInfo Path { get; }
@@ -43,6 +51,8 @@ public sealed class Resource : Node
     public bool IsXml { get; }
 
     public bool ForInvariantCulture => Culture.IsInvariant();
+
+    public bool Contains(string? name) => name is { } && lookup.ContainsKey(name);
 
     public static Resource Load(AdditionalText text, Resources resources)
     {

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -1,7 +1,5 @@
 ﻿#pragma warning disable SA1118 // Parameter should not span multiple lines: readability for descriptions.
 
-using System.Text.RegularExpressions;
-
 namespace DotNetProjectFile;
 
 public static class Rule
@@ -191,6 +189,17 @@ public static class Rule
         tags: new[] { "resx", "resources", "invariant", "localization" },
         category: Category.Bug,
         isEnabled: true);
+
+    public static DiagnosticDescriptor AddInvariantFallbackValues => New(
+       id: 2004,
+       title: "Add invariant fallback values",
+       message: "Add invariant fallback value for '{0}'.",
+       description:
+           "To ensure that localized values can be resolved, a localized value " +
+           "file must have a culture invariant alternative.",
+       tags: new[] { "resx", "resources", "invariant", "localization" },
+       category: Category.Bug,
+       isEnabled: true);
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.


### PR DESCRIPTION
# Proj2004: Add invariant fallback value
To ensure that localized values can be resolved, a localized value must have a culture invariant alternative.

See: https://learn.microsoft.com/en-us/dotnet/core/extensions/localization

See #31 