### PR TITLE
New Rule Proj0011: Define properties once

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ To add a props file:
 * [**Proj0008** Remove folder nodes](rules/Proj0008.md)
 * [**Proj0009** Use the TragetFramework node for a single target framework](rules/Proj0009.md)
 * [**Proj0010** Define OutputType explicitly](rules/Proj0010.md)
+* [**Proj0011** Define properties once](rules/Proj0011.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -115,7 +115,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxNoHeaders", "projects\R
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxNoInvariant", "projects\ResxNoInvariant\ResxNoInvariant.csproj", "{5522D7B2-00F5-45C6-81B7-47EA8D899FF9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ResxMissingInvariant", "projects\ResxMissingInvariant\ResxMissingInvariant.csproj", "{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ResxMissingInvariant", "projects\ResxMissingInvariant\ResxMissingInvariant.csproj", "{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PropertiesTwice", "projects\PropertiesTwice\PropertiesTwice.csproj", "{CA2B4CAD-663A-4992-975A-4D4EAFB60587}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -235,6 +237,10 @@ Global
 		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CA2B4CAD-663A-4992-975A-4D4EAFB60587}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CA2B4CAD-663A-4992-975A-4D4EAFB60587}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CA2B4CAD-663A-4992-975A-4D4EAFB60587}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CA2B4CAD-663A-4992-975A-4D4EAFB60587}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -271,6 +277,7 @@ Global
 		{5D3BAD0B-5B58-42B1-9A91-FFD758CF8F26} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{5522D7B2-00F5-45C6-81B7-47EA8D899FF9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{DF3076CB-B7AD-4BC8-8079-AAEC10B5D4D9} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{CA2B4CAD-663A-4992-975A-4D4EAFB60587} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0008.md = rules\Proj0008.md
 		rules\Proj0009.md = rules\Proj0009.md
 		rules\Proj0010.md = rules\Proj0010.md
+		rules\Proj0011.md = rules\Proj0011.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 		rules\Proj1003.md = rules\Proj1003.md

--- a/projects/PropertiesTwice/Class1.cs
+++ b/projects/PropertiesTwice/Class1.cs
@@ -1,0 +1,7 @@
+﻿namespace PropertiesTwice
+{
+    public class Class1
+    {
+
+    }
+}

--- a/projects/PropertiesTwice/Class1.cs
+++ b/projects/PropertiesTwice/Class1.cs
@@ -1,7 +1,0 @@
-﻿namespace PropertiesTwice
-{
-    public class Class1
-    {
-
-    }
-}

--- a/projects/PropertiesTwice/Placeholder.cs
+++ b/projects/PropertiesTwice/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace PropertiesTwice;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/PropertiesTwice/PropertiesTwice.csproj
+++ b/projects/PropertiesTwice/PropertiesTwice.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ProductName>Test project</ProductName>
-    <Authors>Corniel Nobel, Wesley Baartman</Authors>
+    <Authors>Corniel Nobel; Wesley Baartman</Authors>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <Authors Condition="'2' == '1'">Corniel Nobel, Wesley Baartman</Authors>
+    <Authors Condition="'2' == '1'">Corniel Nobel; Wesley Baartman</Authors>
     <ProductName Condition="'1' == '1'">Test project</ProductName>
   </PropertyGroup>
 

--- a/projects/PropertiesTwice/PropertiesTwice.csproj
+++ b/projects/PropertiesTwice/PropertiesTwice.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ProductName>Test project</ProductName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'1' == '1'">
+    <ProductName>Test project</ProductName>
+  </PropertyGroup>
+
+</Project>

--- a/projects/PropertiesTwice/PropertiesTwice.csproj
+++ b/projects/PropertiesTwice/PropertiesTwice.csproj
@@ -6,6 +6,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ProductName>Test project</ProductName>
+    <Authors>Corniel Nobel, Wesley Baartman</Authors>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,6 +16,11 @@
 
   <PropertyGroup Condition="'1' == '1'">
     <ProductName>Test project</ProductName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <Authors Condition="'2' == '1'">Corniel Nobel, Wesley Baartman</Authors>
+    <ProductName Condition="'1' == '1'">Test project</ProductName>
   </PropertyGroup>
 
 </Project>

--- a/props/common.props
+++ b/props/common.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Authors>Corniel Nobel, Wesley Baartman</Authors>
+    <Authors>Corniel Nobel;  Wesley Baartman</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
     <ProductName>.NET project file analyzers</ProductName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/props/common.props
+++ b/props/common.props
@@ -6,6 +6,13 @@
     <NuGetAudit>true</NuGetAudit>
   </PropertyGroup>
 
+  <PropertyGroup Label="Package">
+    <Authors>Corniel Nobel, Wesley Baartman</Authors>
+    <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
+    <ProductName>.NET project file analyzers</ProductName>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="../../props/common.props" Link="Properties/common.props" />
   </ItemGroup>

--- a/props/common.props
+++ b/props/common.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
-    <Authors>Corniel Nobel;  Wesley Baartman</Authors>
+    <Authors>Corniel Nobel; Wesley Baartman</Authors>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
     <ProductName>.NET project file analyzers</ProductName>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/rules/Proj0003.md
+++ b/rules/Proj0003.md
@@ -64,9 +64,9 @@ namespaces globally in a file.
 ``` C#
 global using System;
 global using System.Collections.Generic;
-global using System.IO;             
-global using System.Linq;           
-global using System.Net.Http;       
-global using System.Threading;  
+global using System.IO;
+global using System.Linq;
+global using System.Net.Http;
+global using System.Threading;
 global using System.Threading.Tasks;
 ```

--- a/rules/Proj0011.md
+++ b/rules/Proj0011.md
@@ -1,5 +1,6 @@
 # Proj0011: Define properties once
-TODO
+As MS Build will only select one value of a property, defining a property twice
+is adding noise, if not a bug.
 
 ## Non-complaint
 ``` XML

--- a/rules/Proj0011.md
+++ b/rules/Proj0011.md
@@ -1,0 +1,31 @@
+# Proj0011: Define properties once
+TODO
+
+## Non-complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
+    <Nullable>annotations</Nullable>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_properties_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_properties_once.cs
@@ -1,0 +1,24 @@
+﻿namespace Rules.MS_Build.Define_properties_once;
+
+public class Reports
+{
+    [Test]
+    public void Properties_defined_before()
+        => new DefinePropertiesOnce()
+        .ForProject("PropertiesTwice.cs")
+        .HasIssues(
+            new Issue("Proj0011", "Property <ImplicitUsings> has been already defined.").WithSpan(/*...*/ 05, 05, 05, 44),
+            new Issue("Proj0011", "Property <TargetFrameworks> has been already defined.").WithSpan(/*.*/ 12, 05, 12, 54),
+            new Issue("Proj0011", "Property <Nullable> has been already defined.").WithSpan(/*.........*/ 13, 05, 13, 36),
+            new Issue("Proj0011", "Property <ProductName> has been already defined.").WithSpan(/*......*/ 22, 05, 22, 66));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantVB.vb")]
+    public void Projects_without_double_properties(string project)
+         => new DefinePropertiesOnce()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineOutputType.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineOutputType.cs
@@ -10,7 +10,7 @@ public sealed class DefineOutputType : MsBuildProjectFileAnalyzer
         if (context.Project.IsProject)
         {
             var outputTypes = context.Project
-                .AncestorsAndSelf()
+                .ImportsAndSelf()
                 .SelectMany(p => p.PropertyGroups)
                 .SelectMany(g => g.OutputType);
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
@@ -1,4 +1,6 @@
-﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+﻿using System.Xml.Linq;
+
+namespace DotNetProjectFile.Analyzers.MsBuild;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public sealed class DefinePropertiesOnce : MsBuildProjectFileAnalyzer
@@ -21,17 +23,22 @@ public sealed class DefinePropertiesOnce : MsBuildProjectFileAnalyzer
     private sealed class PropertyComparer : IEqualityComparer<Node>
     {
         public bool Equals(Node x, Node y)
-            => x.LocalName == y.LocalName
+            => Name(x) == Name(y)
             && Condition(x) == Condition(y);
 
         public int GetHashCode(Node obj)
-            => (obj.LocalName.GetHashCode() * 13)
+            => (Name(obj).GetHashCode() * 13)
             ^ Condition(obj).GetHashCode();
 
+        private static string Name(Node node)
+            => node.LocalName == nameof(TargetFrameworks)
+            ? nameof(TargetFramework)
+            : node.LocalName;
+
         private static string Condition(Node node)
-        => node.AncestorsAndSelf()
-        .Select(n => n.Condition)
-        .FirstOrDefault(c => c is { })
-        ?? string.Empty;
+            => node.AncestorsAndSelf()
+            .Select(n => n.Condition)
+            .FirstOrDefault(c => c is { })
+            ?? string.Empty;
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
@@ -1,0 +1,37 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class DefinePropertiesOnce : MsBuildProjectFileAnalyzer
+{
+    public DefinePropertiesOnce() : base(Rule.DefinePropertiesOnce) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        var props = new HashSet<Node>(new PropertyComparer());
+
+        foreach (var prop in context.Project.PropertyGroups.SelectMany(g => g.Children()))
+        {
+            if (!props.Add(prop))
+            {
+                context.ReportDiagnostic(Descriptor, prop, prop.LocalName);
+            }
+        }
+    }
+
+    private sealed class PropertyComparer : IEqualityComparer<Node>
+    {
+        public bool Equals(Node x, Node y)
+            => x.LocalName == y.LocalName
+            && Condition(x) == Condition(y);
+
+        public int GetHashCode(Node obj)
+            => (obj.LocalName.GetHashCode() * 13)
+            ^ Condition(obj).GetHashCode();
+
+        private static string Condition(Node node)
+        => node.AncestorsAndSelf()
+        .Select(n => n.Condition)
+        .FirstOrDefault(c => c is { })
+        ?? string.Empty;
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
@@ -10,7 +10,7 @@ public sealed class RunNuGetSecurityAuditsAutomatically : MsBuildProjectFileAnal
         if (context.Project.IsProject)
         {
             var audits = context.Project
-                .AncestorsAndSelf()
+                .ImportsAndSelf()
                 .SelectMany(p => p.PropertyGroups)
                 .SelectMany(g => g.NuGetAudit);
 

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
@@ -10,7 +10,7 @@ public sealed class UseAnalyzers : MsBuildProjectFileAnalyzer
         if (context.Project.IsProject)
         {
             var packageReferences = context.Project
-                .AncestorsAndSelf()
+                .ImportsAndSelf()
                 .SelectMany(p => p.ItemGroups)
                 .SelectMany(group => group.PackageReferences)
                 .ToArray();

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzersForPackages.cs
@@ -10,7 +10,7 @@ public sealed class UseAnalyzersForPackages : MsBuildProjectFileAnalyzer
         if (context.Project.IsProject)
         {
             var packageReferences = context.Project
-                .AncestorsAndSelf()
+                .ImportsAndSelf()
                 .SelectMany(p => p.ItemGroups)
                 .SelectMany(group => group.PackageReferences)
                 .ToArray();

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
@@ -10,7 +10,7 @@ public sealed class UseSonarAnalyzers : MsBuildProjectFileAnalyzer
         if (context.Project.IsProject
             && Include(context.Compilation.Options.Language) is { } include
             && context.Project
-                .AncestorsAndSelf()
+                .ImportsAndSelf()
                 .SelectMany(p => p.ItemGroups)
                 .SelectMany(i => i.PackageReferences).None(p => Includes(p, include)))
         {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -20,6 +20,8 @@
     <Version>1.0.6</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- Proj0011: Define properties once (NEW RULE)
 v1.0.6
 - Proj0010: Define OutputType explicitly. (NEW RULE)
 - Proj1001: Reported dependency with missing analyser is now nearest name match. (FP)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -13,12 +13,9 @@
 
   <PropertyGroup Label="Package settings">
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <PackageProjectUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
-    <Authors>Corniel Nobel</Authors>
-    <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
     <Version>1.0.6</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
+++ b/src/DotNetProjectFile.Analyzers/Extensions/Microsoft.CodeAnalysis.Diagnostics.AnalysisContext.cs
@@ -11,7 +11,7 @@ internal static class AnalysisContextExtensions
             if (projects.EntryPoint(c.Compilation.Assembly) is { } project
                 && string.IsNullOrEmpty(project.Element.Name.NamespaceName))
             {
-                foreach (var p in project.AncestorsAndSelf())
+                foreach (var p in project.ImportsAndSelf())
                 {
                     action.Invoke(new(p, c.Compilation, c.Options, c.CancellationToken, c.ReportDiagnostic));
                 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Folder.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Folder.cs
@@ -5,7 +5,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class Folder : Node
 {
-    public Folder(XElement element, Project project) : base(element, project) { }
+    public Folder(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public string? Include => Attribute();
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ImplicitUsings.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ImplicitUsings.cs
@@ -11,7 +11,7 @@ public sealed class ImplicitUsings : Node
         @true,
     }
 
-    public ImplicitUsings(XElement element, Project project) : base(element, project) { }
+    public ImplicitUsings(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public Kind? Value => Convert<Kind?>(Element.Value);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Import.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Import.cs
@@ -5,7 +5,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class Import : Node
 {
-    public Import(XElement element, Project project) : base(element, project) { }
+    public Import(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public Project? Value
     {

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
@@ -21,7 +21,7 @@ public sealed class ItemGroup : Node
     /// <param name="element">
     /// The corresponding <see cref="XElement"/>.
     /// </param>
-    public ItemGroup(XElement element, Project project) : base(element, project)
+    public ItemGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
         PackageReferences = Children<PackageReference>();
         Folders = Children<Folder>();

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -10,15 +10,18 @@ namespace DotNetProjectFile.MsBuild;
 public class Node
 {
     /// <summary>Initializes a new instance of the <see cref="Node"/> class.</summary>
-    protected Node(XElement element, Project? project)
+    protected Node(XElement element, Node? parent, Project? project)
     {
         Element = element;
+        Parent = parent;
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
     }
 
     internal readonly XElement Element;
 
     internal readonly Project Project;
+
+    public Node? Parent { get; }
 
     /// <summary>Gets the local name of the <see cref="Node"/>.</summary>
     public virtual string LocalName => GetType().Name;
@@ -68,16 +71,16 @@ public class Node
     internal Node? Create(XElement element) => element.Name.LocalName switch
     {
         null => null,
-        nameof(Folder) /*...........*/ => new Folder(element, Project),
-        nameof(ImplicitUsings) /*...*/ => new ImplicitUsings(element, Project),
-        nameof(Import) /*...........*/ => new Import(element, Project),
-        nameof(ItemGroup) /*........*/ => new ItemGroup(element, Project),
-        nameof(NuGetAudit) /*.......*/ => new NuGetAudit(element, Project),
-        nameof(OutputType) /*.......*/ => new OutputType(element, Project),
-        nameof(PackageReference) /*.*/ => new PackageReference(element, Project),
-        nameof(PropertyGroup) /*....*/ => new PropertyGroup(element, Project),
-        nameof(TargetFramework) /*..*/ => new TargetFramework(element, Project),
-        nameof(TargetFrameworks) /*.*/ => new TargetFrameworks(element, Project),
+        nameof(Folder) /*...........*/ => new Folder(element, this, Project),
+        nameof(ImplicitUsings) /*...*/ => new ImplicitUsings(element, this, Project),
+        nameof(Import) /*...........*/ => new Import(element, this, Project),
+        nameof(ItemGroup) /*........*/ => new ItemGroup(element, this, Project),
+        nameof(NuGetAudit) /*.......*/ => new NuGetAudit(element, this, Project),
+        nameof(OutputType) /*.......*/ => new OutputType(element, this, Project),
+        nameof(PackageReference) /*.*/ => new PackageReference(element, this, Project),
+        nameof(PropertyGroup) /*....*/ => new PropertyGroup(element, this, Project),
+        nameof(TargetFramework) /*..*/ => new TargetFramework(element, this, Project),
+        nameof(TargetFrameworks) /*.*/ => new TargetFrameworks(element, this, Project),
         _ => new Unknown(element, Project),
     };
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -29,6 +29,8 @@ public class Node
     /// <summary>Gets the label of the node.</summary>
     public string? Label => Attribute();
 
+    public string? Condition => Attribute();
+
     /// <summary>Get the line info.</summary>
     public IXmlLineInfo LineInfo => Element;
 
@@ -52,6 +54,17 @@ public class Node
     /// The <see cref="XNode.ToString()"/> of the underlying <see cref="XElement"/> is called.
     /// </remarks>
     public override string ToString() => Element.ToString();
+
+    public IEnumerable<Node> AncestorsAndSelf()
+    {
+        var parent = this;
+
+        while (parent is { })
+        {
+            yield return parent;
+            parent = parent.Parent;
+        }
+    }
 
     /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
     public Nodes<T> Children<T>() where T : Node => new(this);

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -81,7 +81,7 @@ public class Node
         nameof(PropertyGroup) /*....*/ => new PropertyGroup(element, this, Project),
         nameof(TargetFramework) /*..*/ => new TargetFramework(element, this, Project),
         nameof(TargetFrameworks) /*.*/ => new TargetFrameworks(element, this, Project),
-        _ => new Unknown(element, Project),
+        _ => new Unknown(element, this, Project),
     };
 
     protected T? Convert<T>(string? value, [CallerMemberName] string? propertyName = null)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/NuGetAudit.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/NuGetAudit.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class NuGetAudit : Node
 {
-    public NuGetAudit(XElement element, Node? parent, Project? project) : base(element, project) { }
+    public NuGetAudit(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public bool? Value => Convert<bool?>(Element.Value);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/NuGetAudit.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/NuGetAudit.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class NuGetAudit : Node
 {
-    public NuGetAudit(XElement element, Project? project) : base(element, project) { }
+    public NuGetAudit(XElement element, Node? parent, Project? project) : base(element, project) { }
 
     public bool? Value => Convert<bool?>(Element.Value);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/OutputType.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/OutputType.cs
@@ -12,7 +12,7 @@ public sealed class OutputType : Node
         WinExe,
     }
 
-    public OutputType(XElement element, Project project) : base(element, project) { }
+    public OutputType(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public Kind? Value => Convert<Kind?>(Element.Value);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class PackageReference : Node
 {
-    public PackageReference(XElement element, Project project) : base(element, project) { }
+    public PackageReference(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public string? Include => Attribute();
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -32,13 +32,13 @@ public sealed class Project : Node
 
     public Nodes<ItemGroup> ItemGroups => Children<ItemGroup>();
 
-    public IEnumerable<Project> AncestorsAndSelf()
+    public IEnumerable<Project> ImportsAndSelf()
     {
         foreach (var import in Imports)
         {
             if (import.Value is { } project)
             {
-                foreach (var p in project.AncestorsAndSelf())
+                foreach (var p in project.ImportsAndSelf())
                 {
                     yield return p;
                 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -7,7 +7,7 @@ namespace DotNetProjectFile.MsBuild;
 public sealed class Project : Node
 {
     private Project(FileInfo path, SourceText text, Projects projects, bool isAdditional, bool isProject)
-        : base(XElement.Parse(text.ToString(), LoadOptions), null!)
+        : base(XElement.Parse(text.ToString(), LoadOptions), null, null)
     {
         Path = path;
         Text = text;

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -5,7 +5,7 @@ namespace DotNetProjectFile.MsBuild;
 public sealed class PropertyGroup : Node
 {
     /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
-    public PropertyGroup(XElement element, Project project) : base(element, project)
+    public PropertyGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
         TargetFramework = Children<TargetFramework>();
         TargetFrameworks = Children<TargetFrameworks>();

--- a/src/DotNetProjectFile.Analyzers/MsBuild/TargetFramework.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/TargetFramework.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class TargetFramework : Node
 {
-    public TargetFramework(XElement element, Project? project) : base(element, project) { }
+    public TargetFramework(XElement element, Node? parent, Project? project) : base(element, project) { }
 
     public string? Values => Element.Value;
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/TargetFramework.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/TargetFramework.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class TargetFramework : Node
 {
-    public TargetFramework(XElement element, Node? parent, Project? project) : base(element, project) { }
+    public TargetFramework(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public string? Values => Element.Value;
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/TargetFrameworks.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/TargetFrameworks.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class TargetFrameworks : Node
 {
-    public TargetFrameworks(XElement element, Project? project) : base(element, project) { }
+    public TargetFrameworks(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public IReadOnlyList<string> Values
         => Element.Value?.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Unknown.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Unknown.cs
@@ -4,7 +4,7 @@ namespace DotNetProjectFile.MsBuild;
 
 public sealed class Unknown : Node
 {
-    public Unknown(XElement element, Project project) : base(element, project) { }
+    public Unknown(XElement element, Node parent, Project project) : base(element, parent, project) { }
 
     public override string LocalName => Element.Name.LocalName;
 }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -12,6 +12,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0008** Remove folder nodes](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0008.md)
 * [**Proj0009** Use the TragetFramework node for a single target framework](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0009.md)
 * [**Proj0010** Define OutputType explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0010.md)
+* [**Proj0011** Define properties once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0011.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1003.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -122,7 +122,7 @@ public static class Rule
         id: 0011,
         title: "Define properties once",
         message: "Property <{0}> has been already defined.",
-        description: "Defining properties multiple times .. TODO .",
+        description: "MS Build will only select one value of a property.",
         tags: new[] { "Configuration", "confusion" },
         category: Category.Clarity,
         severity: DiagnosticSeverity.Warning,

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -118,6 +118,16 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor DefinePropertiesOnce => New(
+        id: 0011,
+        title: "Define properties once",
+        message: "Property <{0}> has been already defined.",
+        description: "Defining properties multiple times .. TODO .",
+        tags: new[] { "Configuration", "confusion" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,
         title: "Use the .NET project file analyzers",


### PR DESCRIPTION
# Proj0011: Define properties once
As MS Build will only select one value of a property, defining a property twice
is adding noise, if not a bug.

## Non-complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <Nullable>enable</Nullable>
  </PropertyGroup>

  <PropertyGroup>
    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
    <Nullable>annotations</Nullable>
  </PropertyGroup>

</Project>
```

## Compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <Nullable>enable</Nullable>
  </PropertyGroup>

</Project>
```

See: #15