### PR TITLE
Report obsolete <PackageLicenseUrl> on on node

### DIFF
--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_license_url.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Avoid_license_url.cs
@@ -7,7 +7,8 @@ public class Reports
        => new AvoidLicenseUrl()
        .ForProject("WithLicenseUrl.cs")
        .HasIssue(
-           new Issue("Proj0211", "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node."));
+            new Issue("Proj0211", "Replace deprecated <PackageLicenseUrl> with <PackageLicenseExpression> or <PackageLicenseFile> node.")
+                .WithSpan(29, 5, 29, 120));
 }
 
 public class Guards

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidLicenseUrl.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/AvoidLicenseUrl.cs
@@ -7,17 +7,9 @@ public sealed class AvoidLicenseUrl : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject)
+        foreach (var lincensUrl in context.Project.PropertyGroups.SelectMany(g => g.PackageLicenseUrl))
         {
-            var nodes = context.Project
-                .ImportsAndSelf()
-                .SelectMany(p => p.PropertyGroups)
-                .SelectMany(g => g.PackageLicenseUrl);
-
-            if (nodes.Any())
-            {
-                context.ReportDiagnostic(Descriptor, context.Project);
-            }
+            context.ReportDiagnostic(Descriptor, lincensUrl);
         }
     }
 }


### PR DESCRIPTION
By reporting on node, the IDE will navigate the user directly to the node to change.