### PR TITLE
New rule Proj0214: Define the NuGet project ID explicitly

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,7 +38,6 @@ dotnet_diagnostic.CA1860.severity = none    #  Prefer comparing 'Length' to 0 ra
 
 dotnet_diagnostic.S100.severity  = none     # Properties should be named in PascalCase
 dotnet_diagnostic.S101.severity  = none     # Types should be named in PascalCase
-dotnet_diagnostic.S1694.severity = none     # An abstract class should have both abstract and concrete methods.
 dotnet_diagnostic.S3376.severity = none     # Attribute, EventArgs, and Exception type names should end with the type being extended
 dotnet_diagnostic.S4136.severity = none     # All method overloads should be adjacent.
 
@@ -47,7 +46,6 @@ dotnet_diagnostic.S1144.severity = warning  # Unused private types or members sh
 dotnet_diagnostic.S1185.severity = warning  # Overriding members should do more than simply call the same member in the base class
 dotnet_diagnostic.S1479.severity = warning  # Consider reworking this 'switch' to reduce the number of 'case's to at most 30
 dotnet_diagnostic.S1858.severity = warning  # "ToString()" calls should not be redundant
-dotnet_diagnostic.S1694.severity = warning  # Convert this 'abstract' class to a concrete type with a protected constructor.
 dotnet_diagnostic.S2302.severity = warning  # "nameof" should be used
 dotnet_diagnostic.S2342.severity = warning  # Rename this enumeration to match naming convention
 dotnet_diagnostic.S2436.severity = warning  # Types and methods should not have too many generic parameters

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ To add a props file:
 * [**Proj0211** Avoid using deprecated license definition](rules/Proj0211.md)
 * [**Proj0212** Define the project icon file explicitly](rules/Proj0212.md)
 * [**Proj0213** Define the project icon URL explicitly](rules/Proj0213.md)
+* [**Proj0214** Define the NuGet project ID explicitly](rules/Proj0214.md)
 * [**Proj1000** Use the .NET project file analyzers](rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](rules/Proj1003.md)

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -48,6 +48,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0211.md = rules\Proj0211.md
 		rules\Proj0212.md = rules\Proj0212.md
 		rules\Proj0213.md = rules\Proj0213.md
+		rules\Proj0214.md = rules\Proj0214.md
 		rules\Proj1000.md = rules\Proj1000.md
 		rules\Proj1001.md = rules\Proj1001.md
 		rules\Proj1003.md = rules\Proj1003.md

--- a/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
+++ b/projects/CompliantCSharpPackage/CompliantCSharpPackage.csproj
@@ -11,6 +11,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoAuthors/NoAuthors.csproj
+++ b/projects/NoAuthors/NoAuthors.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Label="PackageInfo">
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoCopyright/NoCopyright.csproj
+++ b/projects/NoCopyright/NoCopyright.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoDescription/NoDescription.csproj
+++ b/projects/NoDescription/NoDescription.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Label="PackageInfo">
     <Version>1.0.0</Version>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoIcon/NoIcon.csproj
+++ b/projects/NoIcon/NoIcon.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoIconUrl/NoIconUrl.csproj
+++ b/projects/NoIconUrl/NoIconUrl.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoLicense/NoLicense.csproj
+++ b/projects/NoLicense/NoLicense.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoReadme/NoReadme.csproj
+++ b/projects/NoReadme/NoReadme.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/NoReleaseNotes/NoReleaseNotes.csproj
+++ b/projects/NoReleaseNotes/NoReleaseNotes.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Label="PackageInfo">
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>

--- a/projects/NoRepositoryUrl/NoRepositoryUrl.csproj
+++ b/projects/NoRepositoryUrl/NoRepositoryUrl.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>

--- a/projects/NoTags/NoTags.csproj
+++ b/projects/NoTags/NoTags.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>

--- a/projects/NoUrl/NoUrl.csproj
+++ b/projects/NoUrl/NoUrl.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Copyright>Copyright © Corniel Nobel 2023-current</Copyright>

--- a/projects/NoVersion/NoVersion.csproj
+++ b/projects/NoVersion/NoVersion.csproj
@@ -9,6 +9,7 @@
   <PropertyGroup Label="PackageInfo">
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/projects/WithLicenseFile/WithLicenseFile.csproj
+++ b/projects/WithLicenseFile/WithLicenseFile.csproj
@@ -10,6 +10,7 @@
     <Version>1.0.0</Version>
     <Description>Awesome library</Description>
     <Authors>Corniel Nobel; Wesley Baartman</Authors>
+    <PackageId>DotNetProjectFile.Anayzers</PackageId>
     <PackageTags>analyzer; coolthings</PackageTags>
     <RepositoryUrl>https://github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>

--- a/rules/Proj0214.md
+++ b/rules/Proj0214.md
@@ -1,0 +1,42 @@
+# Proj0214: Define the NuGet project ID explicitly
+To ensure the creation of well-formed packages, explicitly define the
+`<PackageID>` node or disable package generation by defining the
+`<IsPackable>` node with value `false`.
+
+## Non-complaint
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+  </PropertyGroup>
+
+</Project>
+```
+
+## Compliant
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <IsPackable>true</IsPackable>
+    <PackableId>NuGetPackageId</PackableId>
+  </PropertyGroup>
+
+</Project>
+```
+
+Or
+
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <PackableId>false</PackableId>
+  </PropertyGroup>
+
+</Project>
+```

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_info.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Define_package_info.cs
@@ -18,7 +18,8 @@ public class Reports
            new Issue("Proj0209", "Define the <PackageReadmeFile> node explicitly or define the <IsPackable> node with value 'false'."),
            new Issue("Proj0210", "Define the <PackageLicenseExpression> or <PackageLicenseFile> node explicitly or define the <IsPackable> node with value 'false'."),
            new Issue("Proj0212", "Define the <PackageIcon> node explicitly or define the <IsPackable> node with value 'false'."),
-           new Issue("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'."));
+           new Issue("Proj0213", "Define the <PackageIconUrl> node explicitly or define the <IsPackable> node with value 'false'."),
+           new Issue("Proj0214", "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'."));
 
     [Test]
     public void on_no_version()

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
@@ -15,7 +15,8 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
         Rule.DefineReadmeFile,
         Rule.DefineLicense,
         Rule.DefineIcon,
-        Rule.DefineIconUrl) { }
+        Rule.DefineIconUrl,
+        Rule.DefinePackageId) { }
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
@@ -32,6 +33,7 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
         Analyze(context, Rule.DefineReadmeFile, g => g.PackageReadmeFile);
         Analyze(context, Rule.DefineIcon, g => g.PackageIcon);
         Analyze(context, Rule.DefineIconUrl, g => g.PackageIconUrl);
+        Analyze(context, Rule.DefinePackageId, g => g.PackageId);
 
         Analyze(context, Rule.DefineLicense, g =>
         {

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -18,6 +18,7 @@
   
   <PropertyGroup Label="Package settings">
     <RepositoryType>git</RepositoryType>
+    <PackageId>DotNetProjectFile.Analyzers</PackageId>
     <PackageProjectUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</PackageProjectUrl>
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
@@ -42,6 +43,7 @@ v1.0.7
 - Proj0211: Avoid using deprecated license definition. (NEW RULE)
 - Proj0212: Define the project icon file explicitly. (NEW RULE)
 - Proj0213: Define the project icon URL explicitly. (NEW RULE)
+- Proj0214: Define the NuGet project ID explicitly. (NEW RULE)
 v1.0.6
 - Proj0010: Define OutputType explicitly. (NEW RULE)
 - Proj1001: Reported dependency with missing analyser is now nearest name match. (FP)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageId.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageId.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class PackageId : Node<string>
+{
+    public PackageId(XElement element, Node parent, Project project) : base(element, parent, project) { }
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -19,6 +19,7 @@ public sealed class PropertyGroup : Node
         RepositoryUrl = Children<RepositoryUrl>();
         PackageProjectUrl = Children<PackageProjectUrl>();
         Copyright = Children<Copyright>();
+        PackageId = Children<PackageId>();
         PackageReleaseNotes = Children<PackageReleaseNotes>();
         PackageReadmeFile = Children<PackageReadmeFile>();
         PackageLicenseExpression = Children<PackageLicenseExpression>();
@@ -49,6 +50,8 @@ public sealed class PropertyGroup : Node
     public Nodes<PackageTags> PackageTags { get; }
 
     public Nodes<RepositoryUrl> RepositoryUrl { get; }
+
+    public Nodes<PackageId> PackageId { get; }
 
     public Nodes<PackageProjectUrl> PackageProjectUrl { get; }
 

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -28,6 +28,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0211** Avoid using deprecated license definition](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0211.md)
 * [**Proj0212** Define the project icon file explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0212.md)
 * [**Proj0213** Define the project icon URL explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0213.md)
+* [**Proj0214** Define the NuGet project ID explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0214.md)
 * [**Proj1000** Use the .NET project file analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1000.md)
 * [**Proj1001** Use analyzers for packages](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1001.md)
 * [**Proj1003** Use Sonar analyzers](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj1003.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -341,6 +341,20 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor DefinePackageId => New(
+        id: 0214,
+        title: "Define the NuGet project ID explicitly",
+        message: "Define the <PackageId> node explicitly or define the <IsPackable> node with value 'false'.",
+        description:
+            "To ensure the creation of well-formed packages, " +
+            "explicitly define the <PackageId> node or " +
+            "disable package generation by defining the " +
+            "<IsPackable> node with value 'false'.",
+        tags: new[] { "Configuration", "NuGet", "package" },
+        category: Category.Configuration,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor UseDotNetProjectFileAnalyzers => New(
         id: 1000,
         title: "Use the .NET project file analyzers",


### PR DESCRIPTION
# Proj0214: Define the NuGet project ID explicitly
To ensure the creation of well-formed packages, explicitly define the `<PackageID>` node or disable package generation by defining the `<IsPackable>` node with value `false`.

## Non-complaint
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <IsPackable>true</IsPackable>
  </PropertyGroup>

</Project>
```

## Compliant
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <IsPackable>true</IsPackable>
    <PackableId>NuGetPackageId</PackableId>
  </PropertyGroup>

</Project>
```

Or

``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>net7.0</TargetFramework>
    <PackableId>false</PackableId>
  </PropertyGroup>

</Project>
```
#16