### PR TITLE
Introduction of ApplyToProps

### DIFF
--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineIsPackable.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineIsPackable.cs
@@ -5,13 +5,14 @@ public sealed class DefineIsPackable : MsBuildProjectFileAnalyzer
 {
     public DefineIsPackable() : base(Rule.DefineIsPackable) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject
-            && context.Project
-                .ImportsAndSelf()
-                .SelectMany(p => p.PropertyGroups)
-                .SelectMany(g => g.IsPackable).None())
+        if (context.Project
+            .ImportsAndSelf()
+            .SelectMany(p => p.PropertyGroups)
+            .SelectMany(g => g.IsPackable).None())
         {
             context.ReportDiagnostic(Descriptor, context.Project);
         }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineOutputType.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefineOutputType.cs
@@ -5,19 +5,16 @@ public sealed class DefineOutputType : MsBuildProjectFileAnalyzer
 {
     public DefineOutputType() : base(Rule.DefineOutputType) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject)
+        if (context.Project
+            .ImportsAndSelf()
+            .SelectMany(p => p.PropertyGroups)
+            .SelectMany(g => g.OutputType).None())
         {
-            var outputTypes = context.Project
-                .ImportsAndSelf()
-                .SelectMany(p => p.PropertyGroups)
-                .SelectMany(g => g.OutputType);
-
-            if (outputTypes.None())
-            {
-                context.ReportDiagnostic(Descriptor, context.Project);
-            }
+            context.ReportDiagnostic(Descriptor, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePackageInfo.cs
@@ -18,6 +18,8 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
         Rule.DefineIconUrl,
         Rule.DefinePackageId) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
         if (!IsPackable(context.Project)) { return; }
@@ -44,8 +46,7 @@ public sealed class DefinePackageInfo : MsBuildProjectFileAnalyzer
     }
 
     private static bool IsPackable(MsBuildProject project)
-        => project.IsProject
-        && project.Property<bool?, IsPackable>(g => g.IsPackable, MsBuildDefaults.IsPackage).GetValueOrDefault();
+        => project.Property<bool?, IsPackable>(g => g.IsPackable, MsBuildDefaults.IsPackage).GetValueOrDefault();
 
     private static IEnumerable<Node> GetNodes(ProjectFileAnalysisContext context, Func<PropertyGroup, IEnumerable<Node>> getNodes)
         => context.Project

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RunNuGetSecurityAuditsAutomatically.cs
@@ -5,19 +5,13 @@ public sealed class RunNuGetSecurityAuditsAutomatically : MsBuildProjectFileAnal
 {
     public RunNuGetSecurityAuditsAutomatically() : base(Rule.RunNuGetSecurityAudit) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject)
+        if (context.Project.Property<bool?, NuGetAudit>(g => g.NuGetAudit, MsBuildDefaults.NuGetAudit) != true)
         {
-            var audits = context.Project
-                .ImportsAndSelf()
-                .SelectMany(p => p.PropertyGroups)
-                .SelectMany(g => g.NuGetAudit);
-
-            if (audits.None() || audits.Any(a => a.Value != true))
-            {
-                context.ReportDiagnostic(Descriptor, context.Project);
-            }
+            context.ReportDiagnostic(Descriptor, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseAnalyzers.cs
@@ -5,20 +5,18 @@ public sealed class UseAnalyzers : MsBuildProjectFileAnalyzer
 {
     public UseAnalyzers() : base(Rule.UseDotNetProjectFileAnalyzers) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject)
-        {
-            var packageReferences = context.Project
-                .ImportsAndSelf()
-                .SelectMany(p => p.ItemGroups)
-                .SelectMany(group => group.PackageReferences)
-                .ToArray();
+        var packageReferences = context.Project
+            .ImportsAndSelf()
+            .SelectMany(p => p.ItemGroups)
+            .SelectMany(group => group.PackageReferences);
 
-            if (packageReferences.None(r => r.Include.Contains("DotNetProjectFile.Analyzers", StringComparison.OrdinalIgnoreCase)))
-            {
-                context.ReportDiagnostic(Descriptor, context.Project);
-            }
+        if (packageReferences.None(r => r.Include.Contains("DotNetProjectFile.Analyzers", StringComparison.OrdinalIgnoreCase)))
+        {
+            context.ReportDiagnostic(Descriptor, context.Project);
         }
     }
 }

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/UseSonarAnalyzers.cs
@@ -5,10 +5,11 @@ public sealed class UseSonarAnalyzers : MsBuildProjectFileAnalyzer
 {
     public UseSonarAnalyzers() : base(Rule.UseSonarAnalyzers) { }
 
+    protected override bool ApplyToProps => false;
+
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        if (context.Project.IsProject
-            && Include(context.Compilation.Options.Language) is { } include
+        if (Include(context.Compilation.Options.Language) is { } include
             && context.Project
                 .ImportsAndSelf()
                 .SelectMany(p => p.ItemGroups)

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuildProjectFileAnalyzer.cs
@@ -9,7 +9,9 @@ public abstract class MsBuildProjectFileAnalyzer : DiagnosticAnalyzer
 
     public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
 
-    public DiagnosticDescriptor Descriptor => SupportedDiagnostics[0];
+    protected virtual bool ApplyToProps => true;
+
+    protected DiagnosticDescriptor Descriptor => SupportedDiagnostics[0];
 
     public sealed override void Initialize(AnalysisContext context)
     {
@@ -19,7 +21,13 @@ public abstract class MsBuildProjectFileAnalyzer : DiagnosticAnalyzer
     }
 
     protected virtual void Register(AnalysisContext context)
-        => context.RegisterProjectFileAction(Register);
+        => context.RegisterProjectFileAction(c =>
+        {
+            if (c.Project.IsProject || ApplyToProps)
+            {
+                Register(c);
+            }
+        });
 
     protected abstract void Register(ProjectFileAnalysisContext context);
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/MsBuildDefaults.cs
@@ -3,4 +3,5 @@
 public static class MsBuildDefaults
 {
     public static readonly bool IsPackage = true;
+    public static readonly bool NuGetAudit = false;
 }


### PR DESCRIPTION
There are rules (like `DefineOutputType`) that only on the MS Build project file, and not to the imported props. With this `ApplyToProps` property (default is `true`) this can be done in a better readable way.