### PR TITLE
New rule Proj0013: Include package references once

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To add a props file:
 * [**Proj0010** Define OutputType explicitly](rules/Proj0010.md)
 * [**Proj0011** Define properties once](rules/Proj0011.md)
 * [**Proj0012** Reassign properties with different value](rules/Proj0012.md)
-* [**Proj0013** Include package references once](rules/Proj0013.md)
+* [**Proj0013** Include package references only once](rules/Proj0013.md)
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ To add a props file:
 * [**Proj0010** Define OutputType explicitly](rules/Proj0010.md)
 * [**Proj0011** Define properties once](rules/Proj0011.md)
 * [**Proj0012** Reassign properties with different value](rules/Proj0012.md)
+* [**Proj0013** Include package references once](rules/Proj0013.md)
 * [**Proj0200** Define IsPackable explicitly](rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](rules/Proj0202.md)

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -34,6 +34,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Rules", "Rules", "{50507CD3
 		rules\Proj0010.md = rules\Proj0010.md
 		rules\Proj0011.md = rules\Proj0011.md
 		rules\Proj0012.md = rules\Proj0012.md
+		rules\Proj0013.md = rules\Proj0013.md
 		rules\Proj0200.md = rules\Proj0200.md
 		rules\Proj0201.md = rules\Proj0201.md
 		rules\Proj0202.md = rules\Proj0202.md
@@ -64,6 +65,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "props", "props", "{00669DF6
 		projects\props\common.props = projects\props\common.props
 		projects\props\common1.props = projects\props\common1.props
 		projects\props\common2.props = projects\props\common2.props
+		projects\props\DoublePackageReferences.props = projects\props\DoublePackageReferences.props
 		projects\props\simple.props = projects\props\simple.props
 	EndProjectSection
 EndProject
@@ -175,6 +177,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WithLicenseUrl", "projects\WithLicenseUrl\WithLicenseUrl.csproj", "{C6611228-1213-4D02-B115-F08ED942A8CB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReassignProperties", "projects\ReassignProperties\ReassignProperties.csproj", "{1D89858A-FB69-40A3-A0D3-26670A87281B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DoublePackageReferences", "projects\DoublePackageReferences\DoublePackageReferences.csproj", "{49E400B2-336B-44B7-9F8F-5F42C1D77C79}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -374,6 +378,10 @@ Global
 		{1D89858A-FB69-40A3-A0D3-26670A87281B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D89858A-FB69-40A3-A0D3-26670A87281B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1D89858A-FB69-40A3-A0D3-26670A87281B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{49E400B2-336B-44B7-9F8F-5F42C1D77C79}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{49E400B2-336B-44B7-9F8F-5F42C1D77C79}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{49E400B2-336B-44B7-9F8F-5F42C1D77C79}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{49E400B2-336B-44B7-9F8F-5F42C1D77C79}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -429,6 +437,7 @@ Global
 		{188095BA-5AEF-4EAD-9330-9930D4A8C2FF} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{C6611228-1213-4D02-B115-F08ED942A8CB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{1D89858A-FB69-40A3-A0D3-26670A87281B} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{49E400B2-336B-44B7-9F8F-5F42C1D77C79} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/DoublePackageReferences/DoublePackageReferences.csproj
+++ b/projects/DoublePackageReferences/DoublePackageReferences.csproj
@@ -18,12 +18,4 @@
     <PackageReference Include="Qowaiv" Version="6.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="*.csproj" Visible="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <AdditionalFiles Include="../../props/DoublePackageReferences.props" />
-  </ItemGroup>
-
 </Project>

--- a/projects/DoublePackageReferences/DoublePackageReferences.csproj
+++ b/projects/DoublePackageReferences/DoublePackageReferences.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\props\DoublePackageReferences.props" />
+  <Import Project="../props/DoublePackageReferences.props" />
   
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -16,6 +16,14 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <PackageReference Include="Qowaiv" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="*.csproj" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="../../props/DoublePackageReferences.props" />
   </ItemGroup>
 
 </Project>

--- a/projects/DoublePackageReferences/DoublePackageReferences.csproj
+++ b/projects/DoublePackageReferences/DoublePackageReferences.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="..\props\DoublePackageReferences.props" />
+  
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="5.0.0" />
+    <PackageReference Include="Qowaiv" Version="5.1.1" />
+    <PackageReference Update="Qowaiv" Version="6.4.1" />
+    <PackageReference Update="Qowaiv" Version="6.4.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <PackageReference Include="Qowaiv" Version="6.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/projects/DoublePackageReferences/Placeholder.cs
+++ b/projects/DoublePackageReferences/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace DoublePackageReferences;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/projects/props/DoublePackageReferences.props
+++ b/projects/props/DoublePackageReferences.props
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="5.0.0" />
+    <PackageReference Include="Qowaiv" Version="5.1.1" />
+    <PackageReference Update="Qowaiv" Version="6.0.0" />
+  </ItemGroup>
+  
+</Project>

--- a/rules/Proj0012.md
+++ b/rules/Proj0012.md
@@ -1,3 +1,3 @@
-# Proj0011: Reassign properties with different value
+# Proj0012: Reassign properties with different value
 Reassigning a value in a MS Build file only makes sense when the value differs
 from the imported value.

--- a/rules/Proj0013.md
+++ b/rules/Proj0013.md
@@ -1,0 +1,51 @@
+# Proj0013: Include package references once
+A `<PackageReference>` should only be defined once per package. If (for whatever
+reason) an update is needed in project file, the `Update` attribute should be
+used. Update are only allowed in different files.
+
+## Non-compliant
+### common.props
+``` XML
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="6.0.0" />
+  </ItemGroup>
+  
+</Project>
+```
+### project.csproj
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="6.4.2" />
+    <PackageReference Include="serilog" Version="2.10.0" />
+    <PackageReference Include="serilog" Version="3.0.1" />
+  </ItemGroup>
+  
+</Project>
+```
+
+## Compliant
+### common.props
+``` XML
+<Project>
+
+  <ItemGroup>
+    <PackageReference Include="Qowaiv" Version="6.0.0" />
+  </ItemGroup>
+  
+</Project>
+```
+### project.csproj
+``` XML
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Update="Qowaiv" Version="6.4.2" />
+    <PackageReference Include="serilog" Version="3.0.1" />
+  </ItemGroup>
+  
+</Project>
+```

--- a/rules/Proj0013.md
+++ b/rules/Proj0013.md
@@ -1,4 +1,4 @@
-# Proj0013: Include package references once
+# Proj0013: Include package references only once
 A `<PackageReference>` should only be defined once per package. If (for whatever
 reason) an update is needed in project file, the `Update` attribute should be
 used. Update are only allowed in different files.

--- a/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Rules/MS_Build/Include_package_references_once.cs
@@ -1,0 +1,25 @@
+﻿namespace Rules.MS_Build.Include_package_references_once;
+
+public class Reports
+{
+    [Test]
+    public void on_double_imports()
+       => new IncludePackageReferencesOnce()
+       .ForProject("DoublePackageReferences.cs")
+       .HasIssues(
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(05, 5, 05, 57),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(06, 5, 06, 56),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(10, 5, 10, 57),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(11, 5, 11, 57),
+            new Issue("Proj0013", "Package 'Qowaiv' is already referenced.").WithSpan(13, 5, 13, 56));
+}
+
+public class Guards
+{
+    [TestCase("CompliantCSharp.cs")]
+    [TestCase("CompliantCSharpPackage.cs")]
+    public void Projects_without_issues(string project)
+         => new IncludePackageReferencesOnce()
+        .ForProject(project)
+        .HasNoIssues();
+}

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludePackageReferencesOnce.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/IncludePackageReferencesOnce.cs
@@ -1,0 +1,40 @@
+﻿namespace DotNetProjectFile.Analyzers.MsBuild;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public sealed class IncludePackageReferencesOnce : MsBuildProjectFileAnalyzer
+{
+    public IncludePackageReferencesOnce() : base(Rule.IncludePackageReferencesOnce) { }
+
+    protected override void Register(ProjectFileAnalysisContext context)
+    {
+        var lookup = new Dictionary<Reference, PackageReference>();
+
+        foreach (var reference in context.Project
+            .ImportsAndSelf()
+            .SelectMany(p => p.ItemGroups)
+            .SelectMany(i => i.PackageReferences))
+        {
+            var key = Reference.Create(reference);
+
+            if (lookup.TryGetValue(key, out var existing) && !IsOverride(existing, reference))
+            {
+                context.ReportDiagnostic(Descriptor, reference, key.Name);
+            }
+            else
+            {
+                lookup[key] = reference;
+            }
+        }
+    }
+
+    private static bool IsOverride(PackageReference existing, PackageReference reference)
+        => existing.Project != reference.Project
+        && reference.Update is { Length: > 0 };
+
+    private record struct Reference(string Name, string Condition)
+    {
+        public static Reference Create(PackageReference reference) => new(
+            Name: reference.Include ?? reference.Update ?? string.Empty,
+            Condition: string.Join(" And ", reference.Conditions()));
+    }
+}

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -27,7 +27,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
 ToBeReleased
-- Proj0013: Include package references once. (NEW RULE)
+- Proj0013: Include package references only once. (NEW RULE)
 v1.0.7
 - Proj0011: Define properties once. (NEW RULE)
 - Proj0012: Reassign properties with different value. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -26,6 +26,8 @@
     <Version>1.0.7</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
+ToBeReleased
+- Proj0013: Include package references once. (NEW RULE)
 v1.0.7
 - Proj0011: Define properties once. (NEW RULE)
 - Proj0012: Reassign properties with different value. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PackageReference.cs
@@ -2,9 +2,11 @@
 
 public sealed class PackageReference : Node
 {
-    public PackageReference(XElement element, Node parent, Project project) : base(element, parent, project) { }
+    public PackageReference(XElement element, Node parent, MsBuildProject project) : base(element, parent, project) { }
 
     public string? Include => Attribute();
+
+    public string? Update => Attribute();
 
     public string? Version => Attribute();
 }

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -14,7 +14,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0010** Define OutputType explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0010.md)
 * [**Proj0011** Define properties once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0011.md)
 * [**Proj0012** Reassign properties with different value](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0012.md)
-* [**Proj0013** Include package references once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0013.md)
+* [**Proj0013** Include package references only once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0013.md)
 * [**Proj0200** Define IsPackable explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0202.md)

--- a/src/DotNetProjectFile.Analyzers/README.md
+++ b/src/DotNetProjectFile.Analyzers/README.md
@@ -14,6 +14,7 @@ The package contains analyzers that analyze .NET project files.
 * [**Proj0010** Define OutputType explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0010.md)
 * [**Proj0011** Define properties once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0011.md)
 * [**Proj0012** Reassign properties with different value](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0012.md)
+* [**Proj0013** Include package references once](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0013.md)
 * [**Proj0200** Define IsPackable explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0200.md)
 * [**Proj0201** Define the project version explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0201.md)
 * [**Proj0202** Define the project description explicitly](https://github.com/Corniel/dotnet-project-file-analyzers/blob/main/rules/Proj0202.md)

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -144,6 +144,16 @@ public static class Rule
         severity: DiagnosticSeverity.Warning,
         isEnabled: true);
 
+    public static DiagnosticDescriptor IncludePackageReferencesOnce => New(
+        id: 0013,
+        title: "Include package references once",
+        message: "Package '{0}' is already referenced.",
+        description: "Including package references twice is considered noise.",
+        tags: new[] { "Configuration", "confusion" },
+        category: Category.Clarity,
+        severity: DiagnosticSeverity.Warning,
+        isEnabled: true);
+
     public static DiagnosticDescriptor DefineIsPackable => New(
         id: 0200,
         title: "Define the project packability explicitly",

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -146,7 +146,7 @@ public static class Rule
 
     public static DiagnosticDescriptor IncludePackageReferencesOnce => New(
         id: 0013,
-        title: "Include package references once",
+        title: "Include package references only once",
         message: "Package '{0}' is already referenced.",
         description: "Including package references twice is considered noise.",
         tags: new[] { "Configuration", "confusion" },


### PR DESCRIPTION
# Proj0013: Include package references once
A `<PackageReference>` should only be defined once per package. If (for whatever
reason) an update is needed in project file, the `Update` attribute should be
used. Update are only allowed in different files.

## Non-compliant
### common.props
``` XML
<Project>

  <ItemGroup>
    <PackageReference Include="Qowaiv" Version="6.0.0" />
  </ItemGroup>
  
</Project>
```
### project.csproj
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup>
    <PackageReference Include="Qowaiv" Version="6.4.2" />
    <PackageReference Include="serilog" Version="2.10.0" />
    <PackageReference Include="serilog" Version="3.0.1" />
  </ItemGroup>
  
</Project>
```

## Compliant
### common.props
``` XML
<Project>

  <ItemGroup>
    <PackageReference Include="Qowaiv" Version="6.0.0" />
  </ItemGroup>
  
</Project>
```
### project.csproj
``` XML
<Project Sdk="Microsoft.NET.Sdk">

  <ItemGroup>
    <PackageReference Update="Qowaiv" Version="6.4.2" />
    <PackageReference Include="serilog" Version="3.0.1" />
  </ItemGroup>
  
</Project>
```