### PR TITLE
Improvement: Support choose

### DIFF
--- a/build.sln
+++ b/build.sln
@@ -39,6 +39,8 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "EmptyProjectVB", "projects\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReassignProperties", "projects\ReassignProperties\ReassignProperties.csproj", "{CA23039F-C48E-404A-8A93-1840114392CB}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ChooseWhen", "projects\ChooseWhen\ChooseWhen.csproj", "{41EB23B4-19FE-45B1-8451-7F23860D88D8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -113,6 +115,10 @@ Global
 		{CA23039F-C48E-404A-8A93-1840114392CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CA23039F-C48E-404A-8A93-1840114392CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CA23039F-C48E-404A-8A93-1840114392CB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41EB23B4-19FE-45B1-8451-7F23860D88D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41EB23B4-19FE-45B1-8451-7F23860D88D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41EB23B4-19FE-45B1-8451-7F23860D88D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41EB23B4-19FE-45B1-8451-7F23860D88D8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -133,6 +139,7 @@ Global
 		{0E4A55F9-5C49-40C9-9ACE-3754729074B3} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{8B077413-FB0E-4F44-AA11-7805A6BDC2EB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{CA23039F-C48E-404A-8A93-1840114392CB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{41EB23B4-19FE-45B1-8451-7F23860D88D8} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/dotnet-project-file-analyzers.sln
+++ b/dotnet-project-file-analyzers.sln
@@ -189,6 +189,7 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NonAlphabeticalProjectReferences", "projects\NonAlphabeticalProjectReferences\NonAlphabeticalProjectReferences.csproj", "{B7FC4C41-DB01-4601-BD69-D3A6E901CBDB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DoubleProjectReferences", "projects\DoubleProjectReferences\DoubleProjectReferences.csproj", "{52DD6A7B-995B-40F7-9500-5F643064E960}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChooseWhen", "projects\ChooseWhen\ChooseWhen.csproj", "{12251088-DE11-4DF8-871A-AD731663D2FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -404,6 +405,10 @@ Global
 		{52DD6A7B-995B-40F7-9500-5F643064E960}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{52DD6A7B-995B-40F7-9500-5F643064E960}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{52DD6A7B-995B-40F7-9500-5F643064E960}.Release|Any CPU.Build.0 = Release|Any CPU
+		{12251088-DE11-4DF8-871A-AD731663D2FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{12251088-DE11-4DF8-871A-AD731663D2FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{12251088-DE11-4DF8-871A-AD731663D2FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{12251088-DE11-4DF8-871A-AD731663D2FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -463,6 +468,7 @@ Global
 		{35F17FF8-BAED-4D22-920A-A92BD1E0CABB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{B7FC4C41-DB01-4601-BD69-D3A6E901CBDB} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 		{52DD6A7B-995B-40F7-9500-5F643064E960} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
+		{12251088-DE11-4DF8-871A-AD731663D2FC} = {46AE4B0F-B941-4E9F-B307-7D7D1E168F64}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3AD1EF71-7465-4ED1-81AD-504C430C8251}

--- a/projects/ChooseWhen/ChooseWhen.csproj
+++ b/projects/ChooseWhen/ChooseWhen.csproj
@@ -1,0 +1,27 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <Choose>
+    <When Condition="'$(TargetFramework)'=='net7.0'">
+      <PropertyGroup>
+        <NuGetAudit>true</NuGetAudit>
+      </PropertyGroup>
+      <ItemGroup>
+        <Folder Include="When/" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <NuGetAudit>false</NuGetAudit>
+      </PropertyGroup>
+      <ItemGroup>
+        <Folder Include="Otherwise/" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+
+</Project>

--- a/projects/ChooseWhen/Placeholder.cs
+++ b/projects/ChooseWhen/Placeholder.cs
@@ -1,0 +1,4 @@
+﻿namespace ChooseWhen;
+
+[System.Serializable]
+public sealed class Placeholder { }

--- a/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
+++ b/specs/DotNetProjectFile.Analyzers.Specs/DotNetProjectFile.Analyzers.Specs.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <RootNamespace>Specs</RootNamespace>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <ItemGroup>

--- a/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/MS_Build/Choose_specs.cs
@@ -1,0 +1,38 @@
+﻿using DotNetProjectFile;
+using DotNetProjectFile.Diagnostics;
+
+namespace MS_Build.Choose_specs;
+
+public class Project_contains
+{
+    [Test]
+    public void items_under_Choose()
+        => new NodeReporter()
+        .ForProject("ChooseWhen.cs")
+        .HasIssues(
+            new Issue("Proj9999", "Found TargetFrameworks.").WithSpan(03, 5, 03, 54),
+            new Issue("Proj9999", "Found Nullable.")/*....*/.WithSpan(04, 5, 04, 31),
+            new Issue("Proj9999", "Found NuGetAudit.")/*..*/.WithSpan(10, 9, 10, 37),
+            new Issue("Proj9999", "Found NuGetAudit.")/*..*/.WithSpan(18, 9, 18, 38),
+            new Issue("Proj9999", "Found Folder.")/*......*/.WithSpan(13, 9, 13, 34),
+            new Issue("Proj9999", "Found Folder.")/*......*/.WithSpan(21, 9, 21, 39));
+    
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    private sealed class NodeReporter : MsBuildProjectFileAnalyzer
+    {
+        public NodeReporter() 
+            : base(Rule.New(9999, "", "Found {0}.", "", Array.Empty<string>(), Category.Reliability)) { }
+
+        protected override void Register(ProjectFileAnalysisContext context)
+        {
+            foreach (var prop in context.Project.PropertyGroups.SelectMany(p => p.Children))
+            {
+                context.ReportDiagnostic(Descriptor, prop, prop.LocalName);
+            }
+            foreach (var prop in context.Project.ItemGroups.SelectMany(p => p.Children))
+            {
+                context.ReportDiagnostic(Descriptor, prop, prop.LocalName);
+            }
+        }
+    }
+}

--- a/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
+++ b/specs/DotNetProjectFile.Analyzers.Specs/Properties/GlobalUsings.cs
@@ -8,3 +8,4 @@ global using NUnit.Framework;
 global using System.Diagnostics.Contracts;
 global using System.Text;
 global using Resx = DotNetProjectFile.Analyzers.Resx;
+global using MsBuildProject = DotNetProjectFile.MsBuild.Project;

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/DefinePropertiesOnce.cs
@@ -9,7 +9,7 @@ public sealed class DefinePropertiesOnce : MsBuildProjectFileAnalyzer
     {
         var props = new HashSet<Node>(new PropertyComparer());
 
-        foreach (var prop in context.Project.PropertyGroups.SelectMany(g => g.Children()))
+        foreach (var prop in context.Project.PropertyGroups.SelectMany(g => g.Children))
         {
             if (!props.Add(prop))
             {

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ReassignPropertiesWithDifferentValue.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/ReassignPropertiesWithDifferentValue.cs
@@ -9,7 +9,7 @@ public sealed class ReassignPropertiesWithDifferentValue : MsBuildProjectFileAna
     {
         if (context.Project.Imports.None()) { return; }
 
-        foreach (var prop in context.Project.PropertyGroups.SelectMany(p => p.Children()))
+        foreach (var prop in context.Project.PropertyGroups.SelectMany(p => p.Children))
         {
             if (EarlierAssignement(prop) is { } previous
                 && Equals(prop.Val, previous.Val))
@@ -24,7 +24,7 @@ public sealed class ReassignPropertiesWithDifferentValue : MsBuildProjectFileAna
         foreach (var import in node.Project.SelfAndImports().Skip(1))
         {
             if (import.PropertyGroups
-                .SelectMany(p => p.Children())
+                .SelectMany(p => p.Children)
                 .FirstOrDefault(n => Same(node, n)) is { } previous)
             {
                 return previous;

--- a/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
+++ b/src/DotNetProjectFile.Analyzers/Analyzers/MsBuild/RemoveEmptyNodes.cs
@@ -7,7 +7,7 @@ public sealed class RemoveEmptyNodes : MsBuildProjectFileAnalyzer
 
     protected override void Register(ProjectFileAnalysisContext context)
     {
-        foreach (var node in context.Project.Children())
+        foreach (var node in context.Project.Children)
         {
             Report(node, context, 1);
         }
@@ -17,7 +17,7 @@ public sealed class RemoveEmptyNodes : MsBuildProjectFileAnalyzer
     {
         var noChildren = true;
 
-        foreach (var child in node.Children())
+        foreach (var child in node.Children)
         {
             noChildren = false;
             Report(child, context, level + 1);

--- a/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
+++ b/src/DotNetProjectFile.Analyzers/DotNetProjectFile.Analyzers.csproj
@@ -24,15 +24,16 @@
     <RepositoryUrl>https://www.github.com/Corniel/dotnet-project-file-analyzers</RepositoryUrl>
     <Description>.NET project file analyzers</Description>
     <PackageTags>Code Analysis;Project files;csproj;vbproj;resx;MS Build;resources</PackageTags>
-    <Version>1.0.7</Version>
+    <Version>1.0.8</Version>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageReleaseNotes>
-ToBeReleased
+v1.0.8
 - Proj0013: Include package references only once. (NEW RULE)
 - Proj0014: Include project references only once. (NEW RULE)
 - Proj0015: Order package references alphabetically. (NEW RULE)
 - Proj0016: Order project references alphabetically. (NEW RULE)
 - Proj0400: Define the project publishability explicitly. (NEW RULE)
+- Support &lt;Choose&gt; nodes.
 v1.0.7
 - Proj0011: Define properties once. (NEW RULE)
 - Proj0012: Reassign properties with different value. (NEW RULE)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Choose.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Choose.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class Choose : Node
+{
+    public Choose(XElement element, Node parent, MsBuildProject project) : base(element, parent, project) { }
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis;
+
 namespace DotNetProjectFile.MsBuild;
 
 /// <summary>Represents an item group in a Visual Studio project file.</summary>
@@ -22,6 +24,7 @@ public sealed class ItemGroup : Node
     public ItemGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
         PackageReferences = Children.Typed<PackageReference>();
+        ProjectReferences = Children.Typed<ProjectReference>();
         Folders = Children.Typed<Folder>();
     }
 

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
@@ -1,4 +1,4 @@
-﻿namespace DotNetProjectFile.MsBuild;
+namespace DotNetProjectFile.MsBuild;
 
 /// <summary>Represents an item group in a Visual Studio project file.</summary>
 /// <remarks>
@@ -21,6 +21,8 @@ public sealed class ItemGroup : Node
     /// </param>
     public ItemGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
+        PackageReferences = Children.OfType<PackageReference>();
+        Folders = Children.OfType<Folder>();
         PackageReferences = Children<PackageReference>();
         ProjectReferences = Children<ProjectReference>();
         Folders = Children<Folder>();

--- a/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/ItemGroup.cs
@@ -21,11 +21,8 @@ public sealed class ItemGroup : Node
     /// </param>
     public ItemGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
-        PackageReferences = Children.OfType<PackageReference>();
-        Folders = Children.OfType<Folder>();
-        PackageReferences = Children<PackageReference>();
-        ProjectReferences = Children<ProjectReference>();
-        Folders = Children<Folder>();
+        PackageReferences = Children.Typed<PackageReference>();
+        Folders = Children.Typed<Folder>();
     }
 
     /// <summary>Gets the child package references.</summary>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -14,6 +14,7 @@ public abstract class Node
         Element = element;
         Parent = parent;
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
+        children = new(element.Elements().Select(Create).OfType<Node>().ToArray());
     }
 
     internal readonly XElement Element;
@@ -73,15 +74,17 @@ public abstract class Node
     }
 
     /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
-    public Nodes<T> Children<T>() where T : Node => new(this);
+    public Nodes<T> Children<T>() where T : Node => new(Children().OfType<T>().ToArray());
 
     /// <summary>Get all children.</summary>
     /// <remarks>
     /// This function exists as source for the <see cref="Nodes{T}"/>.
     /// With this construction, we can expose all children as collection.
     /// </remarks>
-    public IEnumerable<Node> Children()
-        => Element.Elements().Select(Create).OfType<Node>();
+    public Nodes<Node> Children() => children;
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Nodes<Node> children;
 
     /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
     public string? Attribute([CallerMemberName] string? propertyName = null)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -30,7 +30,7 @@ public abstract class Node
     /// <summary>Gets the label of the node.</summary>
     public string? Label => Attribute();
 
-    public string? Condition => Attribute();
+    public virtual string? Condition => Attribute();
 
     public IEnumerable<string> Conditions()
         => AncestorsAndSelf()

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Node.cs
@@ -14,7 +14,7 @@ public abstract class Node
         Element = element;
         Parent = parent;
         Project = project ?? (this as Project) ?? throw new ArgumentNullException(nameof(project));
-        children = new(element.Elements().Select(Create).OfType<Node>().ToArray());
+        Children = new(element.Elements().Select(Create).OfType<Node>().ToArray());
     }
 
     internal readonly XElement Element;
@@ -73,18 +73,8 @@ public abstract class Node
         }
     }
 
-    /// <summary>Gets the a <see cref="Nodes{T}"/> of children.</summary>
-    public Nodes<T> Children<T>() where T : Node => new(Children().OfType<T>().ToArray());
-
     /// <summary>Get all children.</summary>
-    /// <remarks>
-    /// This function exists as source for the <see cref="Nodes{T}"/>.
-    /// With this construction, we can expose all children as collection.
-    /// </remarks>
-    public Nodes<Node> Children() => children;
-
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly Nodes<Node> children;
+    public Nodes<Node> Children { get; }
 
     /// <summary>Gets the <see cref="string"/> value of a child element.</summary>
     public string? Attribute([CallerMemberName] string? propertyName = null)

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
@@ -22,7 +22,7 @@ public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
     /// </param>
     public T this[int index] => Items[index];
 
-    public Nodes<TOut> OfType<TOut>() where TOut : T
+    public Nodes<TOut> Typed<TOut>() where TOut : T
         => new(Items.OfType<TOut>().ToArray());
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
@@ -25,6 +25,18 @@ public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
     public Nodes<TOut> Typed<TOut>() where TOut : T
         => new(Items.OfType<TOut>().ToArray());
 
+    public Nodes<TOut> NestedTyped<TOut>() where TOut : T
+        => new(Items.SelectMany(Walk).OfType<TOut>().ToArray());
+
+    private static IEnumerable<Node> Walk(Node node)
+    {
+        yield return node;
+        foreach (var child in node.Children.SelectMany(Walk))
+        {
+            yield return child;
+        }
+    }
+
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
     private string DebuggerDisplay

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
@@ -22,6 +22,9 @@ public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
     /// </param>
     public T this[int index] => Items[index];
 
+    public Nodes<TOut> OfType<TOut>() where TOut : T
+        => new(Items.OfType<TOut>().ToArray());
+
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     [ExcludeFromCodeCoverage/* Justification = "Debug experience only." */]
     private string DebuggerDisplay

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Nodes.cs
@@ -11,13 +11,7 @@ public sealed class Nodes<T> : IReadOnlyList<T> where T : Node
     private readonly IReadOnlyList<T> Items;
 
     /// <summary>Initializes a new instance of the <see cref="Nodes{T}"/> class.</summary>
-    /// <param name="parent">
-    /// The parent <see cref="Node"/>.
-    /// </param>
-    public Nodes(Node parent) => Items = parent.Element
-        .Elements().Select(parent.Create)
-        .OfType<T>()
-        .ToArray();
+    public Nodes(IReadOnlyList<T> items) => Items = items;
 
     /// <summary>Gets the number of items.</summary>
     public int Count => Items.Count;

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
@@ -1,0 +1,12 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class Otherwise : Node
+{
+    public Otherwise(XElement element, Node parent, MsBuildProject project)
+        : base(element, parent, project)
+    {
+        Condition = $"!({string.Join(" And ", parent.Children().OfType<When>().Select(w => w.Condition))})";
+    }
+
+    public override string Condition { get; }
+}

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
@@ -4,7 +4,7 @@ public sealed class Otherwise : Node
 {
     public Otherwise(XElement element, Node parent, MsBuildProject project) : base(element, parent, project) { }
 
-    public override string Condition => condition ?? GetCondtion();
+    public override string Condition => condition ??= GetCondtion();
 
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private string? condition;

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
@@ -2,13 +2,16 @@
 
 public sealed class Otherwise : Node
 {
-    public Otherwise(XElement element, Node parent, MsBuildProject project)
-        : base(element, parent, project)
-    {
-        var whens = parent.Children;
-        
-        Condition = $"!({string.Join(" And ", parent.Children.OfType<When>().Select(w => w.Condition))})";
-    }
+    public Otherwise(XElement element, Node parent, MsBuildProject project) : base(element, parent, project) { }
 
-    public override string Condition { get; }
+    public override string Condition => condition ?? GetCondtion();
+
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private string? condition;
+
+    private string GetCondtion()
+    {
+        var whens = string.Join(" And ", Parent!.Children.OfType<Otherwise>().Select(o => $"({o.Condition})"));
+        return $"!({whens})";
+    }
 }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Otherwise.cs
@@ -5,7 +5,9 @@ public sealed class Otherwise : Node
     public Otherwise(XElement element, Node parent, MsBuildProject project)
         : base(element, parent, project)
     {
-        Condition = $"!({string.Join(" And ", parent.Children().OfType<When>().Select(w => w.Condition))})";
+        var whens = parent.Children;
+        
+        Condition = $"!({string.Join(" And ", parent.Children.OfType<When>().Select(w => w.Condition))})";
     }
 
     public override string Condition { get; }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -25,11 +25,11 @@ public sealed class Project : Node
 
     internal readonly Projects Projects;
 
-    public Nodes<Import> Imports => Children<Import>();
+    public Nodes<Import> Imports => Children.OfType<Import>();
 
-    public Nodes<PropertyGroup> PropertyGroups => Children<PropertyGroup>();
+    public Nodes<PropertyGroup> PropertyGroups => Children.OfType<PropertyGroup>();
 
-    public Nodes<ItemGroup> ItemGroups => Children<ItemGroup>();
+    public Nodes<ItemGroup> ItemGroups => Children.OfType<ItemGroup>();
 
     public TValue? Property<TValue, TNode>(Func<PropertyGroup, Nodes<TNode>> selector, TValue? @default = default)
         where TNode : Node<TValue>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -13,6 +13,9 @@ public sealed class Project : Node
         Projects = projects;
         IsAdditional = isAdditional;
         IsProject = isProject;
+        Imports = Children.Typed<Import>();
+        PropertyGroups = Children.NestedTyped<PropertyGroup>();
+        ItemGroups = Children.NestedTyped<ItemGroup>();
     }
 
     public bool IsAdditional { get; }
@@ -25,11 +28,11 @@ public sealed class Project : Node
 
     internal readonly Projects Projects;
 
-    public Nodes<Import> Imports => Children.Typed<Import>();
+    public Nodes<Import> Imports { get; }
 
-    public Nodes<PropertyGroup> PropertyGroups => Children.Typed<PropertyGroup>();
+    public Nodes<PropertyGroup> PropertyGroups { get; }
 
-    public Nodes<ItemGroup> ItemGroups => Children.Typed<ItemGroup>();
+    public Nodes<ItemGroup> ItemGroups { get; }
 
     public TValue? Property<TValue, TNode>(Func<PropertyGroup, Nodes<TNode>> selector, TValue? @default = default)
         where TNode : Node<TValue>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/Project.cs
@@ -25,11 +25,11 @@ public sealed class Project : Node
 
     internal readonly Projects Projects;
 
-    public Nodes<Import> Imports => Children.OfType<Import>();
+    public Nodes<Import> Imports => Children.Typed<Import>();
 
-    public Nodes<PropertyGroup> PropertyGroups => Children.OfType<PropertyGroup>();
+    public Nodes<PropertyGroup> PropertyGroups => Children.Typed<PropertyGroup>();
 
-    public Nodes<ItemGroup> ItemGroups => Children.OfType<ItemGroup>();
+    public Nodes<ItemGroup> ItemGroups => Children.Typed<ItemGroup>();
 
     public TValue? Property<TValue, TNode>(Func<PropertyGroup, Nodes<TNode>> selector, TValue? @default = default)
         where TNode : Node<TValue>

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -5,28 +5,28 @@ public sealed class PropertyGroup : Node
     /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
     public PropertyGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
-        TargetFramework = Children.OfType<TargetFramework>();
-        TargetFrameworks = Children.OfType<TargetFrameworks>();
-        ImplicitUsings = Children.OfType<ImplicitUsings>();
-        NuGetAudit = Children.OfType<NuGetAudit>();
-        OutputType = Children.OfType<OutputType>();
+        TargetFramework = Children.Typed<TargetFramework>();
+        TargetFrameworks = Children.Typed<TargetFrameworks>();
+        ImplicitUsings = Children.Typed<ImplicitUsings>();
+        NuGetAudit = Children.Typed<NuGetAudit>();
+        OutputType = Children.Typed<OutputType>();
 
-        IsPackable = Children.OfType<IsPackable>();
-        Version = Children.OfType<Version>();
-        Description = Children.OfType<Description>();
-        Authors = Children.OfType<Authors>();
-        PackageTags = Children.OfType<PackageTags>();
-        RepositoryUrl = Children.OfType<RepositoryUrl>();
-        PackageProjectUrl = Children.OfType<PackageProjectUrl>();
-        Copyright = Children.OfType<Copyright>();
-        PackageId = Children.OfType<PackageId>();
-        PackageReleaseNotes = Children.OfType<PackageReleaseNotes>();
-        PackageReadmeFile = Children.OfType<PackageReadmeFile>();
-        PackageLicenseExpression = Children.OfType<PackageLicenseExpression>();
-        PackageLicenseFile = Children.OfType<PackageLicenseFile>();
-        PackageLicenseUrl = Children.OfType<PackageLicenseUrl>();
-        PackageIcon = Children.OfType<PackageIcon>();
-        PackageIconUrl = Children.OfType<PackageIconUrl>();
+        IsPackable = Children.Typed<IsPackable>();
+        Version = Children.Typed<Version>();
+        Description = Children.Typed<Description>();
+        Authors = Children.Typed<Authors>();
+        PackageTags = Children.Typed<PackageTags>();
+        RepositoryUrl = Children.Typed<RepositoryUrl>();
+        PackageProjectUrl = Children.Typed<PackageProjectUrl>();
+        Copyright = Children.Typed<Copyright>();
+        PackageId = Children.Typed<PackageId>();
+        PackageReleaseNotes = Children.Typed<PackageReleaseNotes>();
+        PackageReadmeFile = Children.Typed<PackageReadmeFile>();
+        PackageLicenseExpression = Children.Typed<PackageLicenseExpression>();
+        PackageLicenseFile = Children.Typed<PackageLicenseFile>();
+        PackageLicenseUrl = Children.Typed<PackageLicenseUrl>();
+        PackageIcon = Children.Typed<PackageIcon>();
+        PackageIconUrl = Children.Typed<PackageIconUrl>();
     }
 
     public Nodes<TargetFramework> TargetFramework { get; }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -12,6 +12,7 @@ public sealed class PropertyGroup : Node
         OutputType = Children.Typed<OutputType>();
 
         IsPackable = Children.Typed<IsPackable>();
+        IsPublishable = Children.Typed<IsPublishable>();
         Version = Children.Typed<Version>();
         Description = Children.Typed<Description>();
         Authors = Children.Typed<Authors>();

--- a/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/PropertyGroup.cs
@@ -1,33 +1,32 @@
-﻿namespace DotNetProjectFile.MsBuild;
+namespace DotNetProjectFile.MsBuild;
 
 public sealed class PropertyGroup : Node
 {
     /// <summary>Initializes a new instance of the <see cref="PropertyGroup"/> class.</summary>
     public PropertyGroup(XElement element, Node parent, Project project) : base(element, parent, project)
     {
-        TargetFramework = Children<TargetFramework>();
-        TargetFrameworks = Children<TargetFrameworks>();
-        ImplicitUsings = Children<ImplicitUsings>();
-        NuGetAudit = Children<NuGetAudit>();
-        OutputType = Children<OutputType>();
+        TargetFramework = Children.OfType<TargetFramework>();
+        TargetFrameworks = Children.OfType<TargetFrameworks>();
+        ImplicitUsings = Children.OfType<ImplicitUsings>();
+        NuGetAudit = Children.OfType<NuGetAudit>();
+        OutputType = Children.OfType<OutputType>();
 
-        IsPackable = Children<IsPackable>();
-        Version = Children<Version>();
-        Description = Children<Description>();
-        Authors = Children<Authors>();
-        PackageTags = Children<PackageTags>();
-        RepositoryUrl = Children<RepositoryUrl>();
-        PackageProjectUrl = Children<PackageProjectUrl>();
-        Copyright = Children<Copyright>();
-        PackageId = Children<PackageId>();
-        PackageReleaseNotes = Children<PackageReleaseNotes>();
-        PackageReadmeFile = Children<PackageReadmeFile>();
-        PackageLicenseExpression = Children<PackageLicenseExpression>();
-        PackageLicenseFile = Children<PackageLicenseFile>();
-        PackageLicenseUrl = Children<PackageLicenseUrl>();
-        PackageIcon = Children<PackageIcon>();
-        PackageIconUrl = Children<PackageIconUrl>();
-        IsPublishable = Children<IsPublishable>();
+        IsPackable = Children.OfType<IsPackable>();
+        Version = Children.OfType<Version>();
+        Description = Children.OfType<Description>();
+        Authors = Children.OfType<Authors>();
+        PackageTags = Children.OfType<PackageTags>();
+        RepositoryUrl = Children.OfType<RepositoryUrl>();
+        PackageProjectUrl = Children.OfType<PackageProjectUrl>();
+        Copyright = Children.OfType<Copyright>();
+        PackageId = Children.OfType<PackageId>();
+        PackageReleaseNotes = Children.OfType<PackageReleaseNotes>();
+        PackageReadmeFile = Children.OfType<PackageReadmeFile>();
+        PackageLicenseExpression = Children.OfType<PackageLicenseExpression>();
+        PackageLicenseFile = Children.OfType<PackageLicenseFile>();
+        PackageLicenseUrl = Children.OfType<PackageLicenseUrl>();
+        PackageIcon = Children.OfType<PackageIcon>();
+        PackageIconUrl = Children.OfType<PackageIconUrl>();
     }
 
     public Nodes<TargetFramework> TargetFramework { get; }

--- a/src/DotNetProjectFile.Analyzers/MsBuild/When.cs
+++ b/src/DotNetProjectFile.Analyzers/MsBuild/When.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetProjectFile.MsBuild;
+
+public sealed class When : Node
+{
+    public When(XElement element, Node parent, MsBuildProject project) : base(element, parent, project) { }
+}

--- a/src/DotNetProjectFile.Analyzers/Rule.cs
+++ b/src/DotNetProjectFile.Analyzers/Rule.cs
@@ -492,7 +492,7 @@ public static class Rule
 
 #pragma warning disable S107 // Methods should not have too many parameters
     // it calls a ctor with even more arguments.
-    private static DiagnosticDescriptor New(
+    public static DiagnosticDescriptor New(
         int id,
         string title,
         string message,


### PR DESCRIPTION
Because besides `@Condition`, also `<Choose>` containing `<When>` and `<Otherwise>` can be used to add `<PropertyGroup>`, and  `<ItemGroup>` conditionally, their children should be members of `Project.PropertyGroups` and `Propject.ItemGroups`.

See: #21 